### PR TITLE
chore: Remediate 2 Dependabot security alerts (js-yaml 3.x/4.x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1936,20 +1936,10 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7844,20 +7834,10 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -14267,9 +14247,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Upgrades `js-yaml` from 3.15.0→3.15.1 and 4.3.0→4.3.1 (transitive dev dependencies) to resolve both open Dependabot security alerts.

## NPMPM availability

**Not applicable** — all upgraded packages are dev-only dependencies (`dev: true` in lockfile). No non-dev dependency versions increased.

## Alerts resolved

| Package | Major line | Vulnerable range | Resolved version | Severity | Advisory |
|---------|-----------|-----------------|-----------------|----------|----------|
| js-yaml | 3.x | >= 3.0.0, < 3.15.1 | 3.15.1 | high | GHSA-5p4m-2wfm-xmqj |
| js-yaml | 4.x | >= 4.0.0, < 4.3.1 | 4.3.1 | high | GHSA-5p4m-2wfm-xmqj |

## Remediation details

- **Rung used:** Lockfile splice (HW4) — patch versions 3.15.1 and 4.3.1 are available, so a simple in-place version bump in the lockfile resolves both alerts without any collateral changes.
- **Override added:** No
- **Classification:**
  - ALERT-DRIVEN: `js-yaml` 3.15.0 → 3.15.1 (top-level transitive), `js-yaml` 4.3.0 → 4.3.1 (nested under @eslint/eslintrc, cosmiconfig)
  - COLLATERAL: None
- **Lockfile only:** No `package.json` change required — js-yaml is a transitive dependency, not a direct one.

## Unresolved alerts

None — **merging this PR is expected to CLEAR ALL 2 open Dependabot alerts** for this repo.

## Notes

- The HW2 first-party strip was applied (no `@cloudscape-design/*` entries in lockfile).
- Net diff: lockfile-only, ~46 lines.