### PR TITLE
chore: Add built-in internationalization to button dropdown filtering

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -6372,6 +6372,7 @@ because fixed positioning results in a slight, visible lag when scrolling comple
     },
     {
       "description": "Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.",
+      "i18nTag": true,
       "inlineType": {
         "name": "(matchesCount: number, totalCount: number) => string",
         "parameters": [
@@ -6418,6 +6419,7 @@ types. Items are matched client-side using a case-insensitive substring match ag
     },
     {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": {
         "name": "ButtonDropdownProps.I18nStrings",
         "properties": [

--- a/src/button-dropdown/__tests__/button-dropdown-i18n.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-i18n.test.tsx
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import ButtonDropdown, { ButtonDropdownProps } from '../../../lib/components/button-dropdown';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const items: ButtonDropdownProps.Items = [
+  { id: 'i1', text: 'Cut' },
+  { id: 'i2', text: 'Copy' },
+  { id: 'i3', text: 'Paste' },
+];
+
+function renderDropdown(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  return createWrapper(container).findButtonDropdown()!;
+}
+
+describe('i18n', () => {
+  describe('filteringResultsText', () => {
+    it('uses filteringResultsText from i18n provider when not specified', () => {
+      const wrapper = renderDropdown(
+        <TestI18nProvider
+          messages={{
+            'button-dropdown': {
+              filteringResultsText: '{matchesCount} out of {totalCount} items',
+            },
+          }}
+        >
+          <ButtonDropdown items={items} ariaLabel="Actions" filteringType="auto">
+            Actions
+          </ButtonDropdown>
+        </TestI18nProvider>
+      );
+      wrapper.openDropdown();
+      wrapper.findFilteringInput()!.setInputValue('Co');
+      const footer = wrapper.findFooterRegion();
+      expect(footer).not.toBeNull();
+      expect(footer!.getElement()).toHaveTextContent('1 out of 3 items');
+    });
+
+    it('uses filteringResultsText prop over i18n provider', () => {
+      const wrapper = renderDropdown(
+        <TestI18nProvider
+          messages={{
+            'button-dropdown': {
+              filteringResultsText: '{matchesCount} out of {totalCount} items',
+            },
+          }}
+        >
+          <ButtonDropdown
+            items={items}
+            ariaLabel="Actions"
+            filteringType="auto"
+            filteringResultsText={(matchesCount, totalCount) => `Custom ${matchesCount}/${totalCount}`}
+          >
+            Actions
+          </ButtonDropdown>
+        </TestI18nProvider>
+      );
+      wrapper.openDropdown();
+      wrapper.findFilteringInput()!.setInputValue('Co');
+      const footer = wrapper.findFooterRegion();
+      expect(footer).not.toBeNull();
+      expect(footer!.getElement()).toHaveTextContent('Custom 1/3');
+    });
+  });
+
+  describe('i18nStrings.filteringItemAriaDescription', () => {
+    it('uses i18nStrings.filteringItemAriaDescription from i18n provider when not specified', () => {
+      const wrapper = renderDropdown(
+        <TestI18nProvider
+          messages={{
+            'button-dropdown': {
+              'i18nStrings.filteringItemAriaDescription': 'Continue typing to further filter the list',
+            },
+          }}
+        >
+          <ButtonDropdown items={items} ariaLabel="Actions" filteringType="auto">
+            Actions
+          </ButtonDropdown>
+        </TestI18nProvider>
+      );
+      wrapper.openDropdown();
+      const menuItem = wrapper.findItemById('i1')!.find('[role="menuitem"]')!.getElement();
+      expect(menuItem).toHaveAccessibleDescription('Continue typing to further filter the list');
+    });
+
+    it('uses i18nStrings.filteringItemAriaDescription prop over i18n provider', () => {
+      const wrapper = renderDropdown(
+        <TestI18nProvider
+          messages={{
+            'button-dropdown': {
+              'i18nStrings.filteringItemAriaDescription': 'Continue typing to further filter the list',
+            },
+          }}
+        >
+          <ButtonDropdown
+            items={items}
+            ariaLabel="Actions"
+            filteringType="auto"
+            i18nStrings={{ filteringItemAriaDescription: 'Custom description' }}
+          >
+            Actions
+          </ButtonDropdown>
+        </TestI18nProvider>
+      );
+      wrapper.openDropdown();
+      const menuItem = wrapper.findItemById('i1')!.find('[role="menuitem"]')!.getElement();
+      expect(menuItem).toHaveAccessibleDescription('Custom description');
+    });
+  });
+});

--- a/src/button-dropdown/index.tsx
+++ b/src/button-dropdown/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
+import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
@@ -64,6 +65,8 @@ const ButtonDropdown = React.forwardRef(
     });
     const baseProps = getBaseProps(props);
 
+    const i18n = useInternalI18n('button-dropdown');
+
     const analyticsComponentMetadata: GeneratedAnalyticsMetadataButtonDropdownComponent = {
       name: 'awsui.ButtonDropdown',
       label: `.${analyticsSelectors['trigger-label']}`,
@@ -99,9 +102,18 @@ const ButtonDropdown = React.forwardRef(
         filteringPlaceholder={filteringPlaceholder}
         filteringAriaLabel={filteringAriaLabel}
         filteringClearAriaLabel={filteringClearAriaLabel}
-        filteringResultsText={filteringResultsText}
+        filteringResultsText={i18n(
+          'filteringResultsText',
+          filteringResultsText,
+          format => (matchesCount, totalCount) => format({ matchesCount, totalCount })
+        )}
         noMatch={noMatch}
-        i18nStrings={i18nStrings}
+        i18nStrings={{
+          filteringItemAriaDescription: i18n(
+            'i18nStrings.filteringItemAriaDescription',
+            i18nStrings?.filteringItemAriaDescription
+          ),
+        }}
         {...getAnalyticsMetadataAttribute({
           component: analyticsComponentMetadata,
         })}

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -222,6 +222,7 @@ export interface ButtonDropdownProps extends BaseComponentProps, ExpandToViewpor
 
   /**
    * Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.
+   * @i18n
    */
   filteringResultsText?: (matchesCount: number, totalCount: number) => string;
 
@@ -232,6 +233,7 @@ export interface ButtonDropdownProps extends BaseComponentProps, ExpandToViewpor
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: ButtonDropdownProps.I18nStrings;
 

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -74,6 +74,14 @@ export interface I18nFormatArgTypes {
   button: {
     'i18nStrings.externalIconAriaLabel': never;
   };
+  'button-dropdown': {
+    filteringResultsText: {
+      matchesCount: string | number;
+      totalCount: string | number;
+    };
+    noMatch: never;
+    'i18nStrings.filteringItemAriaDescription': never;
+  };
   calendar: {
     nextMonthAriaLabel: never;
     previousMonthAriaLabel: never;

--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "عرض المسار"
   },
+  "button-dropdown": {
+    "filteringResultsText": "تم نفاد عدد {matchesCount} من {totalCount} من العناصر",
+    "noMatch": "لا توجد إجراءات مطابقة",
+    "i18nStrings.filteringItemAriaDescription": "استمر في الكتابة لتصفية النتائج."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "تفتح الصفحة في علامة تبويب جديدة"
   },

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Pfad anzeigen"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} von {totalCount} Artikeln",
+    "noMatch": "Keine übereinstimmenden Aktionen",
+    "i18nStrings.filteringItemAriaDescription": "Tippen Sie weiter, um die Ergebnisse zu filtern."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Wird in einer neuen Registerkarte geöffnet"
   },

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Show path"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} out of {totalCount} items",
+    "noMatch": "No matching actions",
+    "i18nStrings.filteringItemAriaDescription": "Keep typing to filter results."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Opens in a new tab"
   },

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -55,6 +55,11 @@
   "breadcrumb-group": {
     "expandAriaLabel": "Show path"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} out of {totalCount} items",
+    "noMatch": "No matching actions",
+    "i18nStrings.filteringItemAriaDescription": "Keep typing to filter results."
+  },
   "button": {
     "i18nStrings.externalIconAriaLabel": "Opens in a new tab"
   },

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -58,6 +58,11 @@
   "button": {
     "i18nStrings.externalIconAriaLabel": "Se abre en una pestaña nueva"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} de {totalCount} elementos",
+    "noMatch": "No hay acciones coincidentes",
+    "i18nStrings.filteringItemAriaDescription": "Siga escribiendo para filtrar los resultados."
+  },
   "calendar": {
     "nextMonthAriaLabel": "Próximo mes",
     "previousMonthAriaLabel": "Mes anterior",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -58,6 +58,11 @@
   "button": {
     "i18nStrings.externalIconAriaLabel": "S’ouvre dans un nouvel onglet"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} sur {totalCount} éléments",
+    "noMatch": "Aucune action correspondante",
+    "i18nStrings.filteringItemAriaDescription": "Continuez à taper pour filtrer les résultats."
+  },
   "calendar": {
     "nextMonthAriaLabel": "Mois suivant",
     "previousMonthAriaLabel": "Mois précédent",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -58,6 +58,11 @@
   "button": {
     "i18nStrings.externalIconAriaLabel": "Buka di tab baru"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} dari {totalCount} item",
+    "noMatch": "Tidak ada tindakan yang cocok",
+    "i18nStrings.filteringItemAriaDescription": "Terus mengetik untuk memfilter hasil."
+  },
   "calendar": {
     "nextMonthAriaLabel": "Bulan berikutnya",
     "previousMonthAriaLabel": "Bulan sebelumnya",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -58,6 +58,11 @@
   "button": {
     "i18nStrings.externalIconAriaLabel": "Si apre in una nuova scheda"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} di {totalCount} articoli",
+    "noMatch": "Nessuna azione corrispondente",
+    "i18nStrings.filteringItemAriaDescription": "Continua a digitare per filtrare i risultati."
+  },
   "calendar": {
     "nextMonthAriaLabel": "Mese successivo",
     "previousMonthAriaLabel": "Mese precedente",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -58,6 +58,11 @@
   "button": {
     "i18nStrings.externalIconAriaLabel": "新しいタブで開く"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{totalCount} 件のうち {matchesCount} 件の商品",
+    "noMatch": "一致するアクションなし",
+    "i18nStrings.filteringItemAriaDescription": "入力を続けると結果が絞り込まれます。"
+  },
   "calendar": {
     "nextMonthAriaLabel": "来月",
     "previousMonthAriaLabel": "前月",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -58,6 +58,11 @@
   "button": {
     "i18nStrings.externalIconAriaLabel": "새 탭에서 열림"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{totalCount}개 항목 중 {matchesCount}개",
+    "noMatch": "일치하는 작업 없음",
+    "i18nStrings.filteringItemAriaDescription": "결과를 필터링하려면 계속 입력하세요."
+  },
   "calendar": {
     "nextMonthAriaLabel": "다음 달",
     "previousMonthAriaLabel": "이전 달",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -58,6 +58,11 @@
   "button": {
     "i18nStrings.externalIconAriaLabel": "Abre em uma nova guia"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} de {totalCount} itens",
+    "noMatch": "Nenhuma ação correspondente",
+    "i18nStrings.filteringItemAriaDescription": "Continue digitando para filtrar os resultados."
+  },
   "calendar": {
     "nextMonthAriaLabel": "Próximo mês",
     "previousMonthAriaLabel": "Mês anterior",

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -58,6 +58,11 @@
   "button": {
     "i18nStrings.externalIconAriaLabel": "Yeni bir sekmede açılır"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount}/{totalCount} öge",
+    "noMatch": "Eşleşen eylem yok",
+    "i18nStrings.filteringItemAriaDescription": "Sonuçları filtrelemek için yazmaya devam edin."
+  },
   "calendar": {
     "nextMonthAriaLabel": "Gelecek ay",
     "previousMonthAriaLabel": "Önceki ay",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -58,6 +58,11 @@
   "button": {
     "i18nStrings.externalIconAriaLabel": "在新选项卡中打开"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} 个项目（共 {totalCount} 个）",
+    "noMatch": "没有匹配的操作",
+    "i18nStrings.filteringItemAriaDescription": "继续键入以筛选结果。"
+  },
   "calendar": {
     "nextMonthAriaLabel": "下个月",
     "previousMonthAriaLabel": "上个月",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -58,6 +58,11 @@
   "button": {
     "i18nStrings.externalIconAriaLabel": "在新索引標籤中開啟"
   },
+  "button-dropdown": {
+    "filteringResultsText": "{matchesCount} 個項目 (共 {totalCount} 個）",
+    "noMatch": "沒有相符的動作",
+    "i18nStrings.filteringItemAriaDescription": "繼續輸入以篩選結果。"
+  },
   "calendar": {
     "nextMonthAriaLabel": "下個月",
     "previousMonthAriaLabel": "上個月",


### PR DESCRIPTION
### Description

The translations were around for a while, just forgot to integrate it into the components.

Related links, issue #, if available: n/a

### How has this been tested?

Unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
