### PR TITLE
fix: Fixes programmatic focus in tabs

### DIFF
--- a/pages/tabs/controllability.page.tsx
+++ b/pages/tabs/controllability.page.tsx
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 
-import SpaceBetween from '~components/space-between';
-import Tabs, { TabsProps } from '~components/tabs';
+import { Button, SpaceBetween, Tabs, TabsProps } from '~components';
+
+import { SimplePage } from '../app/templates';
 
 export default function TabsDemoPage() {
   const tabs: Array<TabsProps.Tab> = [
@@ -22,12 +23,14 @@ export default function TabsDemoPage() {
   ];
   const [selectedTab, setSelectedTab] = useState(tabs[0].id);
   return (
-    <>
-      <h1>Tabs</h1>
-
+    <SimplePage title="Tabs">
       <SpaceBetween size="xs">
         <div>
           <h2>Controlled component</h2>
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={() => setSelectedTab(tabs[0].id)}>Select first tab</Button>
+            <Button onClick={() => setSelectedTab(tabs[1].id)}>Select second tab</Button>
+          </SpaceBetween>
           <Tabs
             tabs={tabs}
             activeTabId={selectedTab}
@@ -43,6 +46,6 @@ export default function TabsDemoPage() {
           />
         </div>
       </SpaceBetween>
-    </>
+    </SimplePage>
   );
 }

--- a/src/tabs/__tests__/tabs.test.tsx
+++ b/src/tabs/__tests__/tabs.test.tsx
@@ -275,6 +275,18 @@ describe('Tabs', () => {
 
       expect(wrapper.findActiveTab()!.getElement()).toHaveTextContent('Second tab');
     });
+
+    test('moves the roving tab stop to a programmatically selected tab', () => {
+      const { wrapper, rerender } = renderTabs(<Tabs tabs={defaultTabs} activeTabId="first" onChange={() => void 0} />);
+
+      expect(wrapper.findTabLinkById('first')!.getElement()).toHaveAttribute('tabindex', '0');
+      expect(wrapper.findTabLinkById('second')!.getElement()).toHaveAttribute('tabindex', '-1');
+
+      rerender(<Tabs tabs={defaultTabs} activeTabId="second" onChange={() => void 0} />);
+
+      expect(wrapper.findTabLinkById('first')!.getElement()).toHaveAttribute('tabindex', '-1');
+      expect(wrapper.findTabLinkById('second')!.getElement()).toHaveAttribute('tabindex', '0');
+    });
   });
 
   describe('User interaction (controlled)', () => {

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -172,6 +172,12 @@ export function TabHeaderBar({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [horizontalOverflow, widthChange, tabs.length]);
 
+  // Keep the roving tab stop in sync with the active tab so that keyboard focus
+  // lands on the active tab even when it is selected programmatically.
+  useEffect(() => {
+    setFocusedTabId(activeTabId);
+  }, [activeTabId]);
+
   useEffect(() => {
     scrollIntoViewIfPossible(true);
     // Smooth scrolling should only be called upon activeId change


### PR DESCRIPTION
### Description

Fixes a bug when a tab that is set active programmatically does not override focus target. As result, the user focus lands on the previously active tab (usually the first one), instead of the currently active one. 

Rel: AWSUI-62201

### How has this been tested?

* New unit test and manual testing in the updated test page

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
