### PR TITLE
fix: Improve primary button disabled state contrast in one-theme

### DIFF
--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -62,11 +62,11 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundButtonPrimaryDefault: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
   colorBackgroundButtonPrimaryHover: { light: '{colorNeutral700}', dark: '{colorNeutral200}' },
   colorBackgroundButtonPrimaryActive: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
-  colorBackgroundButtonPrimaryDisabled: { light: '{colorNeutral400}', dark: '{colorNeutral700}' },
+  colorBackgroundButtonPrimaryDisabled: { light: '{colorNeutral150}', dark: '{colorNeutral700}' },
   colorTextButtonPrimaryDefault: { light: '{colorNeutral100}', dark: '{colorNeutral950}' },
   colorTextButtonPrimaryHover: { light: '{colorNeutral50}', dark: '{colorNeutral950}' },
   colorTextButtonPrimaryActive: { light: '{colorNeutral50}', dark: '{colorNeutral950}' },
-  colorTextButtonPrimaryDisabled: { light: '{colorNeutral100}', dark: '{colorNeutral950}' },
+  colorTextButtonPrimaryDisabled: { light: '{colorNeutral500}', dark: '{colorNeutral950}' },
 
   // ── Toggle button ─────────────────────────────────────────────────────────
   colorBackgroundToggleButtonNormalPressed: { light: '{colorWhite}', dark: '{colorNeutral1000}' },


### PR DESCRIPTION
### Description

Issue:
Loading spinners in primary variant disabled buttons have a color contrast ratio of 1.90:1, which fails the WCAG 3:1 minimum 
contrast requirement for non-text graphical elements. Users with low vision have difficulty identifying this content.

Fix:
Updated the primary button disabled state tokens in one-theme (light mode only):

- colorBackgroundButtonPrimaryDisabled: neutral400 (#b7b7b7) → neutral150 (#f8f8f8)
- colorTextButtonPrimaryDisabled: neutral100 (#f9f9f9) → neutral500 (#909090)

New contrast ratio: 3:1 (#909090 on #f8f8f8), meeting the 3:1 requirement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
