### PR TITLE
fix: Restore AI drawer content header top border in dark mode

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -329,6 +329,8 @@ $ai-drawer-heider-height: 42px;
             }
 
             @include theming.dark-mode-only {
+              border-block-start: awsui.$border-divider-section-width solid awsui.$color-border-layout;
+
               @include desktop-only {
                 &:has(+ .drawer-back-to-console-slot) {
                   border-inline-end: awsui.$border-divider-section-width solid awsui.$color-border-layout;


### PR DESCRIPTION
### Description
In visual‑refresh dark mode, the AI drawer's content header is missing the 1px top divider that separates it from the toolbar/tab strip above.

Root cause: in #4733 (commit 600d5711b8) the `border-block-start` on `.drawer-content-header-content` inside the AI drawer was moved from `@include theming.dark-mode-only` to `@include theming.one-theme-only`, rather than being mirrored to both scopes. In the same PR the mirror pattern was applied correctly elsewhere — for example on the sibling `> .drawer-content-container` a few lines below, and on the toolbar rules in `toolbar/styles.scss` — so this looks like a copy‑paste miss.

This change adds `border-block-start` back inside the `dark-mode-only` block while keeping the existing `one-theme-only` rule intact, restoring parity with the PR's stated intent ("Extends toolbar/drawer separator borders to one‑theme (light + dark)").

Related links, issue #, if available: internal AWSUI-62204.

### How has this been tested?

- Manually verified in `pages/app-layout/runtime-drawers` (and `sidecar-demo`) on this branch in dark, light, and one‑theme modes:
  - Dark mode: 1px top divider on the AI drawer's content header is now present (was missing on `main`).
  - Light mode: unchanged — no divider (as before).
  - One‑theme (light and dark): unchanged — divider still present, driven by the existing `one-theme-only` rule.
- Also reproduced the fix end‑to‑end inside the real AWS Console via the internal `AWS-UI-Widget-AppLayout` widget: applied the equivalent patch to the widget's compiled `styles.scoped.css`, rebuilt with the widget's Rollup watcher, loaded the local bundle into the widget test console via the Tampermonkey `local-dev-override.user.js` script, and confirmed the divider between the tabstrip and the "Amazon Q" header — exactly the surface shown in the ticket screenshot — is restored in dark mode.
- `stylelint --ignore-path .gitignore 'src/app-layout/visual-refresh-toolbar/drawer/styles.scss'` passes.
- Change is a 2‑line SCSS addition inside an existing `@include theming.dark-mode-only { ... }` block; no JS, no tokens, no public API touched.

### Review checklist
The following items are to be evaluated by the author(s) and the reviewer(s).

**Correctness**
- [x] Changes include appropriate documentation updates. (n/a — internal styling fix)
- [x] Changes are backward-compatible.
- [x] Changes do not include unsupported browser features.
- [x] Changes were manually tested for accessibility. (visual-only fix — restores a pre‑existing divider; no keyboard/screen‑reader/contrast impact)

**Security**
- [x] If the code handles URLs: all URLs are validated through the checkSafeUrl function. (n/a)

**Testing**
- [ ] Changes are covered with new/existing unit tests. (SCSS‑only regression that isn't easily unit‑tested; relies on the app‑layout visual regression suite already in place. Happy to add a screenshot definition if reviewers prefer.)
- [ ] Changes are covered with new/existing integration tests. (as above)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
