### PR TITLE
chore: Style api v2 tools test pages

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,7 +4,7 @@
     "stylelint-prettier/recommended"
   ],
   "rules": {
-    "custom-property-pattern": "^(?!.+)",
+    "custom-property-pattern": "^awsui-(internal-)?style-",
     "scss/comment-no-empty": null,
     "scss/operator-no-newline-after": null,
     "selector-pseudo-class-no-unknown": [

--- a/pages/styling/custom-panel.scss
+++ b/pages/styling/custom-panel.scss
@@ -1,0 +1,39 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '@cloudscape-design/component-toolkit/internal/style-api' as style-api;
+
+// Illustrates a shared token group.
+$surface: (color-text, color-background, color-border, border-width, border-radius);
+
+$tokens: style-api.resolve(style-api.combine($surface, (color-text-secondary)), carrier);
+
+@include style-api.register($tokens);
+
+.panel {
+  @include style-api.carriers($tokens);
+  box-sizing: border-box;
+  max-inline-size: 360px;
+  background: var(#{style-api.read($tokens, color-background)}, #fcf2f4);
+  border-block: var(#{style-api.read($tokens, border-width)}, 1px) solid
+    var(#{style-api.read($tokens, color-border)}, #ff8da1);
+  border-inline: var(#{style-api.read($tokens, border-width)}, 1px) solid
+    var(#{style-api.read($tokens, color-border)}, #ff8da1);
+  border-start-start-radius: var(#{style-api.read($tokens, border-radius)}, 8px);
+  border-start-end-radius: var(#{style-api.read($tokens, border-radius)}, 8px);
+  border-end-start-radius: var(#{style-api.read($tokens, border-radius)}, 8px);
+  border-end-end-radius: var(#{style-api.read($tokens, border-radius)}, 8px);
+  padding-block: 16px;
+  padding-inline: 16px;
+}
+// Descendant elements can read tokens because of the carrier re-anchoring inside panel.
+.title {
+  color: var(#{style-api.read($tokens, color-text)}, #16191f);
+  font-weight: 700;
+}
+.body {
+  margin-block-start: 8px;
+  color: var(#{style-api.read($tokens, color-text-secondary)}, #5f6b7a);
+}

--- a/pages/styling/custom-panel.tsx
+++ b/pages/styling/custom-panel.tsx
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import styles from './custom-panel.scss';
+
+export interface CustomPanelProps {
+  title: React.ReactNode;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+// A simple custom component that uses --awsui-style-* tokens with a carrier layer, thus allowing nested
+// elements to inherit them.
+export function CustomPanel({ title, className, children }: CustomPanelProps) {
+  return (
+    <div className={clsx(styles.panel, className)}>
+      <div className={styles.title}>{title}</div>
+      <div className={styles.body}>{children}</div>
+    </div>
+  );
+}

--- a/pages/styling/custom-pill.scss
+++ b/pages/styling/custom-pill.scss
@@ -1,0 +1,24 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '@cloudscape-design/component-toolkit/internal/style-api' as style-api;
+
+$tokens: style-api.resolve((color-background, color-border, color-text, border-radius), public);
+
+@include style-api.register($tokens);
+
+.pill {
+  box-sizing: border-box;
+  background: var(#{style-api.read($tokens, color-background)}, #c2185b);
+  color: var(#{style-api.read($tokens, color-text)}, #ffffff);
+  border-block: 1px solid var(#{style-api.read($tokens, color-border)}, #c2185b);
+  border-inline: 1px solid var(#{style-api.read($tokens, color-border)}, #c2185b);
+  border-start-start-radius: var(#{style-api.read($tokens, border-radius)}, 12px);
+  border-start-end-radius: var(#{style-api.read($tokens, border-radius)}, 12px);
+  border-end-start-radius: var(#{style-api.read($tokens, border-radius)}, 12px);
+  border-end-end-radius: var(#{style-api.read($tokens, border-radius)}, 12px);
+  padding-block: 4px;
+  padding-inline: 8px;
+}

--- a/pages/styling/custom-pill.tsx
+++ b/pages/styling/custom-pill.tsx
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import styles from './custom-pill.scss';
+
+export interface CustomPillProps {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+// A simple custom component that uses --awsui-style-* tokens directly (no inheritance and carrier tokens needed).
+export function CustomPill({ className, children }: CustomPillProps) {
+  return <div className={clsx(styles.pill, className)}>{children}</div>;
+}

--- a/pages/styling/style-api-tools.page.tsx
+++ b/pages/styling/style-api-tools.page.tsx
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { Box, SpaceBetween } from '~components';
+
+import { SimplePage } from '../app/templates';
+import { CustomPanel } from './custom-panel';
+import { CustomPill } from './custom-pill';
+
+import overrides from './style-overrides.scss';
+
+export default function StyleApiToolsPage() {
+  return (
+    <SimplePage
+      title="Style API v2: tools"
+      subtitle={
+        <Box variant="span">
+          Applies style-api tools to a set of custom components, which are then themed via{' '}
+          <Box variant="awsui-inline-code">--awsui-style-*</Box> tokens.
+        </Box>
+      }
+      screenshotArea={{}}
+    >
+      <div>
+        <h2>Examples</h2>
+
+        <h3>Without carrier tokens — no token inheritance needed</h3>
+        <SpaceBetween size="s" direction="horizontal">
+          <CustomPill>Default</CustomPill>
+          <CustomPill className={overrides.pill}>Themed</CustomPill>
+        </SpaceBetween>
+
+        <h3>With carrier tokens — style tokens read by descendant elements</h3>
+        <SpaceBetween size="s" direction="horizontal">
+          <CustomPanel title="Default">Default style (no overrides).</CustomPanel>
+          <CustomPanel className={overrides.panel} title="Themed">
+            <SpaceBetween size="s">
+              <span>Themed via --awsui-style-* on the root; the title and body colors resolve through carriers.</span>
+              <CustomPanel title="Default">Default style (no overrides).</CustomPanel>
+            </SpaceBetween>
+          </CustomPanel>
+        </SpaceBetween>
+      </div>
+    </SimplePage>
+  );
+}

--- a/pages/styling/style-overrides.scss
+++ b/pages/styling/style-overrides.scss
@@ -1,0 +1,24 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '~design-tokens' as tokens;
+
+// Consumer style overrides. These can use any values: raw, var(...), light-dark(...), or design tokens.
+
+.panel {
+  --awsui-style-color-background: #{tokens.$color-background-status-info};
+  --awsui-style-color-text: #{tokens.$color-text-status-info};
+  --awsui-style-color-text-secondary: #{tokens.$color-text-body-secondary};
+  --awsui-style-color-border: #{tokens.$color-border-status-info};
+  --awsui-style-border-width: 2px;
+  --awsui-style-border-radius: 4px;
+}
+
+.pill {
+  --awsui-style-color-background: #{tokens.$color-background-status-info};
+  --awsui-style-color-text: #{tokens.$color-text-status-info};
+  --awsui-style-color-border: #{tokens.$color-border-status-info};
+  --awsui-style-border-radius: 4px;
+}


### PR DESCRIPTION
This reverts commit 1f27d345af2d78b08acafdb95cbe8f9370097a03 and re-introduces https://github.com/cloudscape-design/components/pull/4770 with a minor fix applied.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
