### PR TITLE
fix: Extend resize handle pointer target to 24px minimum

### DIFF
--- a/src/internal/components/drag-handle/styles.scss
+++ b/src/internal/components/drag-handle/styles.scss
@@ -39,6 +39,17 @@
 
   &-resize-area {
     cursor: nwse-resize;
+    position: relative;
+
+    // Extend the pointer target to at least 24x24px (WCAG 2.5.8)
+    &::after {
+      content: '';
+      position: absolute;
+      inset-block-end: 0;
+      inset-inline-end: 0;
+      inline-size: max(24px, 100%);
+      block-size: max(24px, 100%);
+    }
 
     @include styles.with-direction('rtl') {
       cursor: nesw-resize;


### PR DESCRIPTION
### Description

Extends the pointer target of the resize handle (`handle-resize-area` in the internal drag-handle component, used by the code editor's resize control) to a minimum of 24x24px to meet WCAG 2.5.8 Target Size (Minimum).

The extension is a transparent `::after` pseudo-element anchored to the handle's bottom-right corner, so it grows only up and left. The visible size of the handle is unchanged, and the extension never overlaps interactive elements below or to the right of the handle. The focus ring already uses `::before`, so there is no conflict.

Related links, issue #, if available: n/a

### How has this been tested?

- `npx jest -c jest.unit.config.js src/internal/components/drag-handle` — all 147 unit tests pass
- `stylelint` on the changed file passes
- Manually verified the enlarged hit area in the dev pages

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
