### PR TITLE
chore: Update all design tokens suffixes to be value-stable

### DIFF
--- a/build-tools/utils/__tests__/token-versions.test.js
+++ b/build-tools/utils/__tests__/token-versions.test.js
@@ -18,13 +18,8 @@ const variablesMap = {
   shadowModal: 'shadow-modal',
 };
 
-test('versions border + typography tokens matched by the default groups and leaves others (incl. border colors) version-less', () => {
-  expect(getTokenVersions(variablesMap)).toEqual({
-    borderRadiusButton: 'v3-1',
-    borderWidthField: 'v3-1',
-    colorChartsPurple300: 'v3-1',
-    fontFamilyBase: 'v3-1',
-  });
+test('versions every token using the default fallback group', () => {
+  expect(getTokenVersions(variablesMap)).toEqual(mapValues(variablesMap, () => 'v3-1'));
 });
 
 test('assigns the version of the first matching group', () => {

--- a/build-tools/utils/token-versions.js
+++ b/build-tools/utils/token-versions.js
@@ -1,17 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const DEFAULT_TOKEN_VERSION = 'v3-1';
-
-// Groups map a token-name pattern (matched against the token's CSS variable name) to a version.
-// Tokens matching no group stay version-less and keep the legacy value-based hashes. Tokens are
-// being migrated in batches (one batch per line), and eventually all tokens will be migrated to
-// the new format.
-const versionGroups = [
-  { pattern: /^border-/, version: DEFAULT_TOKEN_VERSION },
-  { pattern: /^(font|letter-spacing|line-height)-/, version: DEFAULT_TOKEN_VERSION },
-  { pattern: /^color-(charts|severity)-/, version: DEFAULT_TOKEN_VERSION },
-];
+// Groups map a token-name pattern (matched against the token's CSS variable name)
+// to a version. The fallback group (/^.*$/) should always be at the end.
+const versionGroups = [{ pattern: /^.*$/, version: 'v3-1' }];
 
 // Builds the token -> version allowlist from the full token -> cssName map.
 function getTokenVersions(variablesMap, groups = versionGroups) {


### PR DESCRIPTION
### Description

Update all design token suffixes. Previously did it in small batches (border, typography, some colors) but there have been no adverse affects to updating these token names. See #4718, #4845, #4860.

All design token CSS variables have a random hash that depends on two things: token name and token values. This means that if we change a value, the token hash changes completely. This makes the token more subject to change and dependent on the exact commit of the components repo — we wanted this before, but not anymore. Now, the CSS variable suffix depends on: token name and major version ("v3-1"). This means that the suffix only really changes if we change the major version suffix, which makes it more stable across different consumers pulling slightly different versions of the package. See Chorus: rzZV6TJY6Zav

Related links, issue #, if available: n/a

### How has this been tested?

Updated some unit tests. I'll run a dry-run before I merge.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
