### PR TITLE
fix: visible focus ring for inverted links in One Theme (WCAG 2.4.11)

### DIFF
--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -58,6 +58,11 @@
 
   &.color-inverted {
     color: awsui.$color-text-link-inverted-default;
+    @include theming.one-theme-only {
+      #{custom-props.$styleFocusRingBoxShadow}: 0 0 0
+        var(#{custom-props.$styleFocusRingBorderWidth}, awsui.$border-link-focus-ring-shadow-spread)
+        var(#{custom-props.$styleFocusRingBorderColor}, currentColor);
+    }
     &:not(.button) {
       text-decoration-line: underline;
       text-decoration-color: currentColor;


### PR DESCRIPTION
### Description

In One Theme, color="inverted" links used outside a visual context fall back to the colorBorderItemFocused ring, which resolves to the same Indigo600 primitive as the dark notification-style surfaces inverted links are designed for, making the keyboard focus ring invisible (1.00:1 on the link permutations page). Scope the inverted variant's ring fallback to currentColor under One Theme: the ring always matches the (already legible) inverted text color, guaranteeing >= 3:1 wherever the text itself passes, including light-mode flashbar/alert where a static light ring would fail.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
