### PR TITLE
fix: Stop repeating the license header in every compiled stylesheet

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -58,7 +58,27 @@
       "rules": {
         "property-disallowed-list": ["border", "border-radius", "border-style", "margin", "padding"],
         "csstools/use-logical": "always",
-        "@cloudscape-design/no-motion-outside-of-mixin": [true]
+        "@cloudscape-design/no-motion-outside-of-mixin": [true],
+        "@cloudscape-design/license-headers": [
+          true,
+          {
+            "header": "\n Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n SPDX-License-Identifier: Apache-2.0\n",
+            "commentType": "line"
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "./src/**/styles.scss"
+      ],
+      "rules": {
+        "@cloudscape-design/license-headers": [
+          true,
+          {
+            "header": "\n Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n SPDX-License-Identifier: Apache-2.0\n"
+          }
+        ]
       }
     }
   ],

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -58,7 +58,28 @@
       "rules": {
         "property-disallowed-list": ["border", "border-radius", "border-style", "margin", "padding"],
         "csstools/use-logical": "always",
-        "@cloudscape-design/no-motion-outside-of-mixin": [true]
+        "@cloudscape-design/no-motion-outside-of-mixin": [true],
+        "@cloudscape-design/license-headers": [
+          true,
+          {
+            "header": "\n Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n SPDX-License-Identifier: Apache-2.0\n",
+            "commentType": "line"
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "./src/**/styles.scss"
+      ],
+      "rules": {
+        "@cloudscape-design/license-headers": [
+          true,
+          {
+            "header": "\n Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n SPDX-License-Identifier: Apache-2.0\n",
+            "commentType": "block"
+          }
+        ]
       }
     }
   ],

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -8,6 +8,7 @@ Prefer design tokens and custom CSS properties over hardcoded values (colors, sp
 - No descendant combinators (`.a .b` with a space) — breaks CSS scoping because it applies to all `.class-b` elements at unlimited depth
 - Wrap animations in the `with-motion` mixin to ensure motion can be toggled on and off
 - Use logical properties only — no `left`/`right`/`top`/`bottom`/`width`/`height` in CSS. Use `inline-start`/`inline-end`/`block-start`/`block-end`/`inline-size`/`block-size` instead. Required for RTL support.
+- License headers use `//` in partials and `/* */` in `styles.scss` entry points. Sass copies block comments into the compiled CSS, so a partial's header would otherwise be repeated in the output of every entry point that `@use`s it. Stylelint enforces the right form for each.
 
 References:
 - [Mappings for sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values/Sizing#mappings_for_dimensions)

--- a/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/design-tokens.test.ts.snap
@@ -3318,29 +3318,29 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "shadow-card": {
@@ -6975,29 +6975,29 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "shadow-card": {
@@ -10632,29 +10632,29 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "shadow-card": {
@@ -14289,29 +14289,29 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "shadow-card": {
@@ -17946,29 +17946,29 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "shadow-card": {
@@ -21603,29 +21603,29 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-none-35003c",
-            "disabled": "awsui-none-35003c",
+            "default": "awsui-none-592d6e",
+            "disabled": "awsui-none-592d6e",
           },
         },
         "shadow-card": {
@@ -25260,29 +25260,29 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
     "motion-keyframes-fade-in": {
       "$description": "The CSS keyframes for showing an element.",
       "$value": {
-        "default": "awsui-fade-in-35003c",
-        "disabled": "awsui-fade-in-35003c",
+        "default": "awsui-fade-in-592d6e",
+        "disabled": "awsui-fade-in-592d6e",
       },
     },
     "motion-keyframes-fade-out": {
       "$description": "The CSS keyframes for hiding an element.",
       "$value": {
-        "default": "awsui-fade-out-35003c",
-        "disabled": "awsui-fade-out-35003c",
+        "default": "awsui-fade-out-592d6e",
+        "disabled": "awsui-fade-out-592d6e",
       },
     },
     "motion-keyframes-scale-popup": {
       "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
       "$value": {
-        "default": "awsui-none-35003c",
-        "disabled": "awsui-none-35003c",
+        "default": "awsui-none-592d6e",
+        "disabled": "awsui-none-592d6e",
       },
     },
     "motion-keyframes-status-icon-error": {
       "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
       "$value": {
-        "default": "awsui-none-35003c",
-        "disabled": "awsui-none-35003c",
+        "default": "awsui-none-592d6e",
+        "disabled": "awsui-none-592d6e",
       },
     },
     "shadow-card": {
@@ -28922,29 +28922,29 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-scale-popup-35003c",
-            "disabled": "awsui-scale-popup-35003c",
+            "default": "awsui-scale-popup-592d6e",
+            "disabled": "awsui-scale-popup-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-status-icon-error-35003c",
-            "disabled": "awsui-status-icon-error-35003c",
+            "default": "awsui-status-icon-error-592d6e",
+            "disabled": "awsui-status-icon-error-592d6e",
           },
         },
         "shadow-card": {
@@ -32579,29 +32579,29 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-scale-popup-35003c",
-            "disabled": "awsui-scale-popup-35003c",
+            "default": "awsui-scale-popup-592d6e",
+            "disabled": "awsui-scale-popup-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-status-icon-error-35003c",
-            "disabled": "awsui-status-icon-error-35003c",
+            "default": "awsui-status-icon-error-592d6e",
+            "disabled": "awsui-status-icon-error-592d6e",
           },
         },
         "shadow-card": {
@@ -36236,29 +36236,29 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-scale-popup-35003c",
-            "disabled": "awsui-scale-popup-35003c",
+            "default": "awsui-scale-popup-592d6e",
+            "disabled": "awsui-scale-popup-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-status-icon-error-35003c",
-            "disabled": "awsui-status-icon-error-35003c",
+            "default": "awsui-status-icon-error-592d6e",
+            "disabled": "awsui-status-icon-error-592d6e",
           },
         },
         "shadow-card": {
@@ -39893,29 +39893,29 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-scale-popup-35003c",
-            "disabled": "awsui-scale-popup-35003c",
+            "default": "awsui-scale-popup-592d6e",
+            "disabled": "awsui-scale-popup-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-status-icon-error-35003c",
-            "disabled": "awsui-status-icon-error-35003c",
+            "default": "awsui-status-icon-error-592d6e",
+            "disabled": "awsui-status-icon-error-592d6e",
           },
         },
         "shadow-card": {
@@ -43550,29 +43550,29 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-scale-popup-35003c",
-            "disabled": "awsui-scale-popup-35003c",
+            "default": "awsui-scale-popup-592d6e",
+            "disabled": "awsui-scale-popup-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-status-icon-error-35003c",
-            "disabled": "awsui-status-icon-error-35003c",
+            "default": "awsui-status-icon-error-592d6e",
+            "disabled": "awsui-status-icon-error-592d6e",
           },
         },
         "shadow-card": {
@@ -47207,29 +47207,29 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-scale-popup-35003c",
-            "disabled": "awsui-scale-popup-35003c",
+            "default": "awsui-scale-popup-592d6e",
+            "disabled": "awsui-scale-popup-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-status-icon-error-35003c",
-            "disabled": "awsui-status-icon-error-35003c",
+            "default": "awsui-status-icon-error-592d6e",
+            "disabled": "awsui-status-icon-error-592d6e",
           },
         },
         "shadow-card": {
@@ -50864,29 +50864,29 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-scale-popup-35003c",
-            "disabled": "awsui-scale-popup-35003c",
+            "default": "awsui-scale-popup-592d6e",
+            "disabled": "awsui-scale-popup-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-status-icon-error-35003c",
-            "disabled": "awsui-status-icon-error-35003c",
+            "default": "awsui-status-icon-error-592d6e",
+            "disabled": "awsui-status-icon-error-592d6e",
           },
         },
         "shadow-card": {
@@ -54521,29 +54521,29 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
         "motion-keyframes-fade-in": {
           "$description": "The CSS keyframes for showing an element.",
           "$value": {
-            "default": "awsui-fade-in-35003c",
-            "disabled": "awsui-fade-in-35003c",
+            "default": "awsui-fade-in-592d6e",
+            "disabled": "awsui-fade-in-592d6e",
           },
         },
         "motion-keyframes-fade-out": {
           "$description": "The CSS keyframes for hiding an element.",
           "$value": {
-            "default": "awsui-fade-out-35003c",
-            "disabled": "awsui-fade-out-35003c",
+            "default": "awsui-fade-out-592d6e",
+            "disabled": "awsui-fade-out-592d6e",
           },
         },
         "motion-keyframes-scale-popup": {
           "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
           "$value": {
-            "default": "awsui-scale-popup-35003c",
-            "disabled": "awsui-scale-popup-35003c",
+            "default": "awsui-scale-popup-592d6e",
+            "disabled": "awsui-scale-popup-592d6e",
           },
         },
         "motion-keyframes-status-icon-error": {
           "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
           "$value": {
-            "default": "awsui-status-icon-error-35003c",
-            "disabled": "awsui-status-icon-error-35003c",
+            "default": "awsui-status-icon-error-592d6e",
+            "disabled": "awsui-status-icon-error-592d6e",
           },
         },
         "shadow-card": {
@@ -58178,29 +58178,29 @@ exports[`Design tokens artifacts Design tokens JSON for visual-refresh matches t
     "motion-keyframes-fade-in": {
       "$description": "The CSS keyframes for showing an element.",
       "$value": {
-        "default": "awsui-fade-in-35003c",
-        "disabled": "awsui-fade-in-35003c",
+        "default": "awsui-fade-in-592d6e",
+        "disabled": "awsui-fade-in-592d6e",
       },
     },
     "motion-keyframes-fade-out": {
       "$description": "The CSS keyframes for hiding an element.",
       "$value": {
-        "default": "awsui-fade-out-35003c",
-        "disabled": "awsui-fade-out-35003c",
+        "default": "awsui-fade-out-592d6e",
+        "disabled": "awsui-fade-out-592d6e",
       },
     },
     "motion-keyframes-scale-popup": {
       "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
       "$value": {
-        "default": "awsui-scale-popup-35003c",
-        "disabled": "awsui-scale-popup-35003c",
+        "default": "awsui-scale-popup-592d6e",
+        "disabled": "awsui-scale-popup-592d6e",
       },
     },
     "motion-keyframes-status-icon-error": {
       "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
       "$value": {
-        "default": "awsui-status-icon-error-35003c",
-        "disabled": "awsui-status-icon-error-35003c",
+        "default": "awsui-status-icon-error-592d6e",
+        "disabled": "awsui-status-icon-error-592d6e",
       },
     },
     "shadow-card": {

--- a/src/action-card/constants.scss
+++ b/src/action-card/constants.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles/tokens' as awsui;
 

--- a/src/action-card/mixins.scss
+++ b/src/action-card/mixins.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:map';
 @use '../internal/styles/tokens' as awsui;

--- a/src/action-card/motion.scss
+++ b/src/action-card/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/alert/motion.scss
+++ b/src/alert/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/app-layout/constants.scss
+++ b/src/app-layout/constants.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/app-layout/visual-refresh/background.scss
+++ b/src/app-layout/visual-refresh/background.scss
@@ -1,7 +1,6 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 @use '../../internal/styles/' as styles;
 @use '../../internal/styles/tokens' as awsui;
 @use '../../internal/generated/custom-css-properties/index.scss' as custom-props;

--- a/src/app-layout/visual-refresh/breadcrumbs.scss
+++ b/src/app-layout/visual-refresh/breadcrumbs.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../internal/styles/' as styles;
 @use '../../internal/styles/tokens' as awsui;

--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -1,7 +1,6 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 @use '../../internal/styles/tokens' as awsui;
 @use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
 @use '../../internal/styles' as styles;

--- a/src/app-layout/visual-refresh/header.scss
+++ b/src/app-layout/visual-refresh/header.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 header.content {
   grid-area: header;

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../constants' as constants;
 @use '../../internal/generated/custom-css-properties/index.scss' as custom-props;

--- a/src/app-layout/visual-refresh/main.scss
+++ b/src/app-layout/visual-refresh/main.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../internal/styles/' as styles;
 @use '../../internal/styles/tokens' as awsui;

--- a/src/app-layout/visual-refresh/mobile-toolbar.scss
+++ b/src/app-layout/visual-refresh/mobile-toolbar.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../internal/styles/' as styles;
 @use '../../internal/styles/tokens' as awsui;

--- a/src/app-layout/visual-refresh/navigation.scss
+++ b/src/app-layout/visual-refresh/navigation.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../internal/styles/' as styles;
 @use '../../internal/styles/tokens' as awsui;

--- a/src/app-layout/visual-refresh/notifications.scss
+++ b/src/app-layout/visual-refresh/notifications.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../internal/styles/' as styles;
 @use '../../internal/styles/tokens' as awsui;

--- a/src/app-layout/visual-refresh/split-panel.scss
+++ b/src/app-layout/visual-refresh/split-panel.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../internal/styles/' as styles;
 @use '../../internal/styles/tokens' as awsui;

--- a/src/app-layout/visual-refresh/tools.scss
+++ b/src/app-layout/visual-refresh/tools.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;

--- a/src/app-layout/visual-refresh/trigger-button.scss
+++ b/src/app-layout/visual-refresh/trigger-button.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;

--- a/src/area-chart/motion.scss
+++ b/src/area-chart/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/attribute-editor/motion.scss
+++ b/src/attribute-editor/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as tokens;

--- a/src/box/base-styles.scss
+++ b/src/box/base-styles.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 /* stylelint-disable @cloudscape-design/no-implicit-descendant */
 @use '../internal/styles' as styles;

--- a/src/box/layout.scss
+++ b/src/box/layout.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use './spacing.scss' as spacing;

--- a/src/box/spacing.scss
+++ b/src/box/spacing.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 /* stylelint-disable @cloudscape-design/no-implicit-descendant */
 @use 'sass:map';

--- a/src/box/text.scss
+++ b/src/box/text.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 /* stylelint-disable @cloudscape-design/no-implicit-descendant */
 @use './base-styles.scss' as base-styles;

--- a/src/box/visual-accent.scss
+++ b/src/box/visual-accent.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:map';
 @use '../internal/styles/tokens' as awsui;

--- a/src/button/constants.scss
+++ b/src/button/constants.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:color';
 @use '../internal/styles' as styles;

--- a/src/calendar/calendar.scss
+++ b/src/calendar/calendar.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles/tokens' as awsui;
 

--- a/src/calendar/motion.scss
+++ b/src/calendar/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles/index' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/code-editor/ace-editor.scss
+++ b/src/code-editor/ace-editor.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/code-editor/background-inline-svg.scss
+++ b/src/code-editor/background-inline-svg.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:map';
 @use 'sass:list';

--- a/src/code-editor/pane.scss
+++ b/src/code-editor/pane.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/collection-preferences/content-display/content-display-list.scss
+++ b/src/collection-preferences/content-display/content-display-list.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;

--- a/src/collection-preferences/content-display/content-display-option.scss
+++ b/src/collection-preferences/content-display/content-display-option.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;

--- a/src/collection-preferences/visible-content.scss
+++ b/src/collection-preferences/visible-content.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/container/shared.scss
+++ b/src/container/shared.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/date-range-picker/motion.scss
+++ b/src/date-range-picker/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles/index' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/dropdown/motion.scss
+++ b/src/dropdown/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/file-token-group/constants.scss
+++ b/src/file-token-group/constants.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles/tokens' as awsui;
 

--- a/src/flashbar/collapsible.motion.scss
+++ b/src/flashbar/collapsible.motion.scss
@@ -1,7 +1,6 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as tokens;
 

--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -1,7 +1,6 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 @use 'sass:map';
 @use '../internal/generated/custom-css-properties/index.scss' as custom-props;
 @use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;

--- a/src/flashbar/motion.scss
+++ b/src/flashbar/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as tokens;

--- a/src/form-field/motion.scss
+++ b/src/form-field/motion.scss
@@ -1,7 +1,6 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 // This file holds icon hover motions, emitted only for themes that opt in to
 // expressive motion via the `$expressive-motion-themes` list in

--- a/src/icon/mixins.scss
+++ b/src/icon/mixins.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:map';
 @use '../internal/styles' as styles;

--- a/src/internal/components/button-trigger/motion.scss
+++ b/src/internal/components/button-trigger/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;

--- a/src/internal/components/chart-legend/motion.scss
+++ b/src/internal/components/chart-legend/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;

--- a/src/internal/components/chart-series-details/motion.scss
+++ b/src/internal/components/chart-series-details/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;

--- a/src/internal/components/drag-handle-wrapper/motion.scss
+++ b/src/internal/components/drag-handle-wrapper/motion.scss
@@ -1,7 +1,6 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
 @use '../../generated/custom-css-properties/index.scss' as custom-props;

--- a/src/internal/components/expand-toggle-button/motion.scss
+++ b/src/internal/components/expand-toggle-button/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../../internal/styles' as styles;
 @use '../../../internal/styles/tokens' as tokens;

--- a/src/internal/components/option/constants.scss
+++ b/src/internal/components/option/constants.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;

--- a/src/internal/styles/direction.scss
+++ b/src/internal/styles/direction.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @mixin with-direction($direction) {
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features */

--- a/src/internal/styles/forms/constants.scss
+++ b/src/internal/styles/forms/constants.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../utils/theming' as theming;
 @use '../tokens' as awsui;

--- a/src/internal/styles/forms/index.scss
+++ b/src/internal/styles/forms/index.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @forward './constants';
 @forward './mixins';

--- a/src/internal/styles/forms/mixins.scss
+++ b/src/internal/styles/forms/mixins.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:map';
 @use 'sass:meta';

--- a/src/internal/styles/foundation/breakpoints.scss
+++ b/src/internal/styles/foundation/breakpoints.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 // Breakpoints
 $breakpoint-xxx-small: 0;

--- a/src/internal/styles/foundation/index.scss
+++ b/src/internal/styles/foundation/index.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @forward './breakpoints';
 @forward './shadows';

--- a/src/internal/styles/foundation/shadows.scss
+++ b/src/internal/styles/foundation/shadows.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../utils/theming' as theming;
 @use '../tokens' as awsui;

--- a/src/internal/styles/global-vars.scss
+++ b/src/internal/styles/global-vars.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 $stickyVerticalTopOffset: --awsui-sticky-vertical-top-offset;
 $stickyVerticalBottomOffset: --awsui-sticky-vertical-bottom-offset;

--- a/src/internal/styles/global.scss
+++ b/src/internal/styles/global.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use './tokens' as awsui;
 @use 'awsui:resolved-tokens' as resolved-tokens;

--- a/src/internal/styles/index.scss
+++ b/src/internal/styles/index.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @forward './direction';
 @forward './forms';

--- a/src/internal/styles/links.scss
+++ b/src/internal/styles/links.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:map';
 @use './tokens' as awsui;

--- a/src/internal/styles/motion/animations.scss
+++ b/src/internal/styles/motion/animations.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use './mixins' as mixins;
 @use '../../../internal/styles/tokens' as awsui;

--- a/src/internal/styles/motion/index.scss
+++ b/src/internal/styles/motion/index.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @forward './animations';
 @forward './mixins';

--- a/src/internal/styles/motion/mixins.scss
+++ b/src/internal/styles/motion/mixins.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../utils/theming' as theming;
 

--- a/src/internal/styles/style-api.scss
+++ b/src/internal/styles/style-api.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @forward '@cloudscape-design/component-toolkit/internal/style-api';
 

--- a/src/internal/styles/tokens.scss
+++ b/src/internal/styles/tokens.scss
@@ -1,6 +1,4 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @forward 'awsui:tokens';

--- a/src/internal/styles/typography/constants.scss
+++ b/src/internal/styles/typography/constants.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../utils/theming' as theming;
 @use '../tokens' as awsui;

--- a/src/internal/styles/typography/index.scss
+++ b/src/internal/styles/typography/index.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @forward './constants';
 @forward './mixins';

--- a/src/internal/styles/typography/mixins.scss
+++ b/src/internal/styles/typography/mixins.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../tokens' as awsui;
 @use './constants' as constants;

--- a/src/internal/styles/utils/index.scss
+++ b/src/internal/styles/utils/index.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @forward './mixins';
 @forward './styles-reset';

--- a/src/internal/styles/utils/mixins.scss
+++ b/src/internal/styles/utils/mixins.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../tokens' as awsui;
 @use '../typography' as typography;

--- a/src/internal/styles/utils/styles-reset.scss
+++ b/src/internal/styles/utils/styles-reset.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../typography' as typography;
 

--- a/src/internal/styles/utils/theming.scss
+++ b/src/internal/styles/utils/theming.scss
@@ -1,7 +1,6 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 @mixin dark-mode-only($selector: '') {
   @media not print {
     /* stylelint-disable selector-combinator-disallowed-list, selector-class-pattern */

--- a/src/internal/styles/utils/theming.scss
+++ b/src/internal/styles/utils/theming.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:list';
 @use 'sass:map';

--- a/src/item-card/motion.scss
+++ b/src/item-card/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/link/constants.scss
+++ b/src/link/constants.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:map';
 @use '../internal/styles/typography/constants.scss' as styles;

--- a/src/mixed-line-bar-chart/motion.scss
+++ b/src/mixed-line-bar-chart/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/modal/motion.scss
+++ b/src/modal/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/pie-chart/constants.scss
+++ b/src/pie-chart/constants.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/pie-chart/motion.scss
+++ b/src/pie-chart/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/popover/arrow.scss
+++ b/src/popover/arrow.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/popover/body.scss
+++ b/src/popover/body.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/popover/container.scss
+++ b/src/popover/container.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/popover/motion.scss
+++ b/src/popover/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as tokens;

--- a/src/progress-bar/motion.scss
+++ b/src/progress-bar/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/segmented-control/segment.scss
+++ b/src/segmented-control/segment.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:map';
 @use '../internal/styles' as styles;

--- a/src/slider/mixins.scss
+++ b/src/slider/mixins.scss
@@ -1,7 +1,6 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/generated/custom-css-properties/index.scss' as custom-props;

--- a/src/spinner/mixins.scss
+++ b/src/spinner/mixins.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use 'sass:map';
 @use '../internal/styles' as styles;

--- a/src/status-indicator/motion.scss
+++ b/src/status-indicator/motion.scss
@@ -1,7 +1,6 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 /* stylelint-disable selector-max-type */
 @use '../internal/styles' as styles;

--- a/src/token/constants.scss
+++ b/src/token/constants.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;

--- a/src/token/mixins.scss
+++ b/src/token/mixins.scss
@@ -1,7 +1,6 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/generated/custom-css-properties/index.scss' as custom-props;

--- a/src/tutorial-panel/components/tutorial-list/motion.scss
+++ b/src/tutorial-panel/components/tutorial-list/motion.scss
@@ -1,7 +1,5 @@
-/*
- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 @use '../../../internal/styles' as styles;
 @use '../../../internal/styles/tokens' as tokens;


### PR DESCRIPTION
### Description

Fixes #4905.

Sass copies loud comments into the compiled CSS, so each partial's license header was emitted once per entry point that `@use`s it. Every published stylesheet carried a median of 34 copies, and **580 KB of the 2305 KB of CSS was the same four lines repeated**.

The 91 partials under `src/` now declare the header with Sass line comments, which the compiler strips. The `styles.scss` entry points keep the block comment, so every output file still carries one. `.stylelintrc` enforces the right form for each using the `commentType` option added in cloudscape-design/build-tools#75.

| | before | after |
| --- | --- | --- |
| CSS, raw | 2305 KB | **1745 KB** (-24.3%) |
| CSS, gzipped | 303 KB | 298 KB (-1.8%) |
| license header bytes | 580 KB (25.2%) | 32 KB (1.8%) |
| headers, total | 5400 | 297 |
| headers per stylesheet, median | 34 | 1 |
| headers per stylesheet, max | 51 | 5 |
| stylesheets with more than one | 152 | 48 |

The gzipped win is small because gzip already deduped the identical blocks. The win is in unminified bytes, which is what dev servers serve and what the internal package ships. Minified production bundles are unaffected either way, since minifiers strip the comments already.

Two things reviewers should know:

**1. Every generated scoped class name changes.** The name is `awsui_{name}_{fileHash}_{contentHash}_{lineNumber}`, and removing comments moves both the content hash and the line numbers. No snapshot needs updating, though: the `test-utils` selectors snapshot truncates to the path-derived hash, and since #4936, keyframe names derive from stable per-keyframe hashes rather than from a hash of `src/internal/styles/global.scss`, so the design tokens and `themes` snapshots no longer move with this change either. The compiled CSS is otherwise identical, verified as described below.

**2. This does not remove every duplicate.** 48 stylesheets still carry more than one header, up to 5. That remainder is a Dart Sass behaviour, not something this repo controls: an entry point's leading comments are re-emitted once per module when the entry point and its partials share a dependency. Minimal repro on Sass 1.89.2, no Cloudscape code involved:

```scss
// _shared.scss
.shared { color: gray; }
@mixin m { color: gray; }

// _a.scss     -> @use "shared";  .a { color: red; }
// _b.scss     -> @use "shared";  .b { color: blue; }

// entry.scss
/* ENTRY HEADER */
@use "shared";
@use "a";
@use "b";
```

`ENTRY HEADER` is emitted three times. This is the shape of every Cloudscape component that has sub-partials, which is why `popover` still ends up with several headers rather than one. It accounts for roughly 6 KB and is worth a follow-up upstream; it does not block this change.

The other source named in #4905, `@cloudscape-design/component-toolkit`, is already resolved: cloudscape-design/component-toolkit#248 converted its two SCSS files and shipped in `1.0.0-beta.182`, which this branch builds against. That is why the median here reaches 1 rather than 2.

### How has this been tested?

A normalised comparison of all 229 compiled stylesheets against a build of `main` from the same `node_modules`. After neutralising license blocks and the `contentHash`/`lineNumber` segments of scoped names, **all 229 stylesheets are byte-identical**. No file was added, removed, or left empty.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


