### PR TITLE
fix: Enlarge SideNavigation expandable caret pointer target to 24px (WCAG 2.5.8)

### DIFF
--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -31,6 +31,10 @@ $icon-offset-container: awsui.$space-xxs;
 $icon-total-space-normal: calc(#{$icon-width-normal} + #{$icon-margin-left} + #{$icon-margin-right-normal});
 $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{$icon-margin-right-medium});
 
+// Extra inline padding that widens the navigation caret pointer target to 24px (WCAG 2.5.8).
+$nav-caret-pad-normal: calc(24px - #{$icon-width-normal});
+$nav-caret-pad-one-theme: 12px; // 24px minus the one-theme x-small (12px) icon
+
 .root {
   @include styles.styles-reset;
   @include styles.text-wrapping;
@@ -266,6 +270,27 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
       outline: none;
       text-decoration: none;
       flex-direction: column;
+
+      // Widen the pointer target to 24px (WCAG 2.5.8) with inline padding and an
+      // equal negative margin: the extra width grows away from the header label
+      // into the adjacent gutter, so neither the glyph nor the label moves and
+      // the label link keeps its own clicks. Vertical size already fills the row.
+      &:not(.icon-container-end) {
+        padding-inline-start: $nav-caret-pad-normal;
+        margin-inline-start: calc(#{$icon-margin-left} - #{$nav-caret-pad-normal});
+        @include theming.one-theme-only {
+          padding-inline-start: $nav-caret-pad-one-theme;
+          margin-inline-start: calc(-1 * #{$nav-caret-pad-one-theme});
+        }
+      }
+      &.icon-container-end {
+        padding-inline-end: $nav-caret-pad-normal;
+        margin-inline-end: calc(-1 * #{$nav-caret-pad-normal});
+        @include theming.one-theme-only {
+          padding-inline-end: $nav-caret-pad-one-theme;
+          margin-inline-end: calc(-1 * #{$nav-caret-pad-one-theme});
+        }
+      }
 
       &:hover {
         color: awsui.$color-text-expandable-section-hover;


### PR DESCRIPTION
### Description

Fixes a WCAG 2.5.8 (Target Size Minimum) finding: the SideNavigation expandable-link-group chevron caret button had a pointer target only as wide as its icon glyph, 12px in One Theme, 16px in Classic/Visual Refresh, below the 24px minimum.

**This is a width-only change.** The vertical target was already conformant: the caret button stretches to the full row height (28px comfortable / 24px compact) via flex stretch.

The clickable box is widened to 24px using inline padding compensated by an equal negative margin, so the extra width lands entirely in the adjacent non-interactive gutter:

- **Start icon position** (default): grows into the ~20px leading gutter (the `space-l` negative-margin seating).
- **End icon position** (`withIcons`): grows into the trailing gutter instead, because the label link's own click box (its negative-margin overhang) sits flush against the caret's inline-start edge, growing start-ward there would capture the link's clicks.

**Zero layout shift**: the caret glyph and the label link do not move (verified pixel-identical positions before/after in both themes), and pixel probes at the caret/link boundary confirm click ownership is unchanged. Behavior is the same across Classic, Visual Refresh, and One Theme, the tokens involved resolve identically; only the padding delta differs because the icon glyph is 16px vs 12px. Stacked link groups tile cleanly (24px target ≤ 24px compact row pitch), with no target overlap between rows.

Related links, issue #, if available: n/a

### How has this been tested?

- Measured in devtools on the SideNavigation permutations dev page across One Theme / Visual Refresh, comfortable / compact, and both expand icon positions: caret button box is 24×28 (comfortable) and 24×24 (compact) after the change; glyph and label positions unchanged; before/after pixel probes at the caret/label boundary show identical click ownership.
- Functional check: clicking the newly added far-edge pixels toggles the section without triggering the header link.
- Existing unit suites: `src/expandable-section` + `src/side-navigation` (365 tests) pass.
- Existing integration suites: `src/expandable-section/__integ__` + `src/side-navigation/__integ__` pass.
- No new unit test: pure target-size CSS change, matching the `inline-icon-pointer-target` precedent; coverage is the a11y audit re-run plus existing permutation screenshots (visual regression runs in CI on this PR).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
