### PR TITLE
chore: Allow Portal's hidden SSR placeholder in the SSR test

### DIFF
--- a/src/__tests__/functional-tests/ssr.test.ts
+++ b/src/__tests__/functional-tests/ssr.test.ts
@@ -24,6 +24,14 @@ afterEach(() => {
 
 const vrOnlyComponents = ['app-layout-toolbar'];
 
+// Components whose entire tree is rendered through a portal. The server renderer has no
+// container to portal into, so none of their content reaches the server markup. Portal
+// itself renders a hidden placeholder element in its place, so that the markup matches
+// the first client render and hydration succeeds; the client replaces it on the first
+// commit. Older component-toolkit versions emit nothing at all, hence the optional match.
+const portaledComponents = ['modal', 'tooltip'];
+const emptyOrHiddenPlaceholder = /^(<span style="display:none"><\/span>)?$/;
+
 test('ensure is it not DOM', () => {
   expect(typeof window).toBe('undefined');
   expect(typeof CSS).toBe('undefined');
@@ -34,9 +42,9 @@ for (const componentName of getAllComponents().filter(component => vrOnlyCompone
     const { default: Component } = requireComponent(componentName);
     const props = getRequiredPropsForComponent(componentName);
     const content = renderToStaticMarkup(React.createElement(Component, props, 'test content'));
-    if (componentName === 'modal' || componentName === 'tooltip') {
-      // modal and tooltip use portal API which does not work on server and returns an empty content
-      expect(content.length).toEqual(0);
+    if (portaledComponents.indexOf(componentName) !== -1) {
+      expect(content).not.toContain('test content');
+      expect(content).toMatch(emptyOrHiddenPlaceholder);
     } else {
       expect(content.length).toBeGreaterThan(0);
     }


### PR DESCRIPTION
This PR updates a test assertion that will fail once cloudscape-design/component-toolkit#249 is merged. It should be merged first to prevent the tests in this repo from failing.

### Description

`Portal` renders a hidden probe span on its first render so its layout effect can read `ref.current.ownerDocument`. That span was gated on `typeof document !== 'undefined'`, so the server emitted nothing while the client's first render emitted the span — a server/client branch on a DOM global, which React reports as `Hydration failed because the server rendered HTML didn't match the client` before discarding and re-rendering the subtree. The toolkit fix renders the span during SSR too, so both passes agree.

`Portal` is the sole root of both `InternalModal` (`src/modal/internal.tsx:82`) and `Tooltip` (`src/internal/components/tooltip/index.tsx:73`), so their server markup *is* the Portal's output. That takes it from `""` to `<span style="display:none"></span>`, and this assertion fails:

```js
if (componentName === 'modal' || componentName === 'tooltip') {
  // modal and tooltip use portal API which does not work on server and returns an empty content
  expect(content.length).toEqual(0);
}
```

The comment also encodes the assumption the toolkit fix invalidates — the portal API not working on the server is exactly why the first render has to match, not a reason to emit nothing.

The new assertion in this PR asserts what the test actually cares about: the portaled content is not in the server markup, and whatever *is* emitted is either nothing or the hidden placeholder.