### PR TITLE
fix: Avoid mixed-unit max() in drag handle resize area styles

### DIFF
--- a/src/internal/components/drag-handle/styles.scss
+++ b/src/internal/components/drag-handle/styles.scss
@@ -47,8 +47,11 @@
       position: absolute;
       inset-block-end: 0;
       inset-inline-end: 0;
-      inline-size: max(24px, 100%);
-      block-size: max(24px, 100%);
+      // min-*-size instead of `max(24px, 100%)`, which Sass can misinterpret due to mixed units
+      inline-size: 100%;
+      block-size: 100%;
+      min-inline-size: 24px;
+      min-block-size: 24px;
     }
 
     @include styles.with-direction('rtl') {

--- a/src/internal/components/drag-handle/styles.scss
+++ b/src/internal/components/drag-handle/styles.scss
@@ -47,7 +47,6 @@
       position: absolute;
       inset-block-end: 0;
       inset-inline-end: 0;
-      // min-*-size instead of `max(24px, 100%)`, which Sass can misinterpret due to mixed units
       inline-size: 100%;
       block-size: 100%;
       min-inline-size: 24px;


### PR DESCRIPTION
### Description
The drag handle resize area used `inline-size: max(24px, 100%)` / `block-size: max(24px, 100%)`, introduced in a1b16ac. The CSS `max()` function with mixed units (px and %) can be misinterpreted by Sass in downstream builds, causing build failures. Same class of issue as #4882 (fixed in 2041ec8).

This replaces it with an exact CSS equivalent that uses no `max()` at all: `inline-size`/`block-size: 100%` with `min-inline-size`/`min-block-size: 24px`. Min constraints always win when the computed size is smaller, so the pointer target still expands to at least 24x24px (WCAG 2.5.8) and otherwise fills the handle. No functional change.

Related links, issue #, if available: #4882

### How has this been tested?
- `npm run quick-build` passes; verified the compiled `lib/components/internal/components/drag-handle/styles.scoped.css` contains the plain declarations with no mixed-unit `max()`
- `npx stylelint` passes on the file

<details>
   <summary>Review checklist</summary>
_The following items are to be evaluated by the author(s) and the reviewer(s)._
#### Correctness
- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._
#### Security
- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._
#### Testing
- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.