### PR TITLE
chore: Add skipBrowsers option to screenshot test definitions

### DIFF
--- a/test/definitions/types.ts
+++ b/test/definitions/types.ts
@@ -10,6 +10,7 @@ export type Wrapper = ReturnType<typeof createWrapper>;
 export interface ScreenshotTestConfiguration {
   width?: number;
   height?: number;
+  skipBrowsers?: string[];
 }
 
 // 'screenshotArea' — captures the .screenshot-area element on the page.

--- a/test/definitions/visual/area-chart.ts
+++ b/test/definitions/visual/area-chart.ts
@@ -81,7 +81,7 @@ const suite: TestSuite = {
       description: 'selects correct series when navigated back from legend',
       path: 'area-chart/test',
       screenshotType: 'viewport',
-      configuration: { width: 800, height: 800 },
+      configuration: { width: 800, height: 800, skipBrowsers: ['Safari'] },
       setup: async ({ page }) => {
         // Focus and close the filtering select
         await page.click(TEST_CHART_FILTER_TRIGGER);


### PR DESCRIPTION
### Description
This test was originally Safari-skipped in the integration tests. The skip was dropped when it migrated to the test-definitions format, because `ScreenshotTestConfiguration` had no field to express it, and it now fails on the internal Safari runner. Adding the field back lets us restore the skip.

**Changes**
- Add optional `skipBrowsers?: string[]` to `ScreenshotTestConfiguration` (`test/definitions/types.ts`).
- Restore `skipBrowsers: ['Safari']` on the area-chart "selects correct series when navigated back from legend" test (`test/definitions/visual/area-chart.ts`).

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: (will share link for reviewer internally)

### How has this been tested?
build passes (run before commit). Field is ignored on the Chrome-only GitHub runner; internal pipeline skips it on Safari.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
