### PR TITLE
test: Cut WebDriver round-trips in two flaky integ tests

### DIFF
--- a/src/collection-preferences/content-display/__integ__/pages/content-display-page.ts
+++ b/src/collection-preferences/content-display/__integ__/pages/content-display-page.ts
@@ -4,8 +4,22 @@
 import CollectionPreferencesPageObject from '../../../__integ__/pages/collection-preferences-page';
 
 export default class ContentDisplayPageObject extends CollectionPreferencesPageObject {
+  // Reads every option label in a single script evaluation. Fetching them through the
+  // WebDriver protocol costs one round-trip per element, which is 50 for the long list and
+  // dominated the runtime of these tests on CI. Returns the same strings as getText(),
+  // both before and after the list is scrolled.
+  async getOptionTexts(): Promise<string[]> {
+    return (await this.browser.execute(
+      selector =>
+        Array.prototype.map.call(document.querySelectorAll(selector), element =>
+          (element as HTMLElement).innerText.trim()
+        ),
+      this.findOptions().toSelector()
+    )) as string[];
+  }
+
   async containsOptionsInOrder(options: string[]) {
-    const texts = await this.getElementsText(this.findOptions().toSelector());
+    const texts = await this.getOptionTexts();
     const result = texts.join(`\n`).includes(options.join('\n'));
     if (!result) {
       throw new Error(`Options are not in the expected order:

--- a/src/modal/__integ__/modal.test.ts
+++ b/src/modal/__integ__/modal.test.ts
@@ -67,17 +67,30 @@ test(
     const modalContent = modal.findContent();
     const footerSelector = modal.findFooter().toSelector();
     for (let i = 0; i < 100; i++) {
-      page.keys('Tab');
+      await page.keys('Tab');
       const input = modalContent
         .findAll('div')
         .get(i + 1)
         .find('input');
       const inputSelector = input.toSelector();
-      expect(await page.isFocused(inputSelector)).toBe(true);
-      const inputBox = await page.getBoundingBox(inputSelector);
-      const footerBox = await page.getBoundingBox(footerSelector);
-      const inputCenter = inputBox.top + inputBox.height / 2;
-      expect(inputCenter).toBeLessThan(footerBox.top);
+      // Collected in a single script evaluation. Asking for the focus state and the two
+      // bounding boxes separately costs three WebDriver round-trips per iteration, which
+      // over 100 iterations put this test at the edge of its timeout on CI.
+      const { isFocused, inputCenter, footerTop } = await browser.execute(
+        (inputSel: string, footerSel: string) => {
+          const inputElement = document.querySelector(inputSel)!;
+          const inputRect = inputElement.getBoundingClientRect();
+          return {
+            isFocused: document.activeElement === inputElement,
+            inputCenter: inputRect.top + inputRect.height / 2,
+            footerTop: document.querySelector(footerSel)!.getBoundingClientRect().top,
+          };
+        },
+        inputSelector,
+        footerSelector
+      );
+      expect(isFocused).toBe(true);
+      expect(inputCenter).toBeLessThan(footerTop);
     }
   })
 );


### PR DESCRIPTION
### Description

Two integration tests have been taking turns failing the `dry-run` workflow, and they are currently blocking unrelated PRs (e.g. https://github.com/cloudscape-design/components/pull/4908) and the merge queue.

They're the two slowest tests in their respective files, and both typically finish just under the 60s `testTimeout`. Every failure is a bare timeout.

Both tests are latency-bound: almost all their time goes to per-element WebDriver calls that cost 100–350 ms on a CI runner (`jest.integ.config.js` sets `maxWorkers: cpus × 3`, so browser sessions are oversubscribed there).

The fix in this PR is to make the tests faster by reducing the number of chromedriver commands. I counted commands by running chromedriver with `--log-level=ALL` and tallying `COMMAND` entries:

| test | before | after |
|---|---|---|
| `modal` › should not let the sticky footer cover focused elements | 509 | **211** |
| `content-reordering` › scrolls if necessary | 155 | **55** |

**`modal.test.ts`** — the loop ran 100 iterations, each spending 5 commands: one `PerformActions` for the Tab, then `isFocused` (a `FindElement` plus an `ExecuteScript`) and two `getBoundingBox` calls. The focus check and both rects now come back from one `ExecuteScript`, so each iteration costs 2. `getBoundingBox` is itself `getBoundingClientRect`, so the values are unchanged.

**`content-display-page.ts`** — `containsOptionsInOrder` called `getElementsText`, which is one round-trip per element. The long list has 50 options and the test reads it twice, so ~100 of its 155 commands were just fetching labels. One script evaluation returns them all. Every test in that file benefits, not only the failing one.

Also **awaited the `page.keys('Tab')`** at `modal.test.ts:70`, which was the one un-awaited call in the loop. chromedriver serialises commands per session so ordering happened to hold, but it floated a promise whose rejection nothing would surface. This is a latent bug, not the cause of the timeouts.

### What I deliberately did not change

The `for` loop in `scrolls if necessary` sleeps a fixed 200 ms per iteration (`await new Promise(resolve => setTimeout(resolve, 200))`), 6s in total. Replacing that with `page.waitForJsTimers()` looks like the obvious cleanup, and I measured it — it makes CI *slower*, because the sleep is wall-clock and does not inflate under load, whereas `waitForJsTimers` is another round-trip that does. Sending all 30 `ArrowDown` presses in one command would be cheaper still, but it changes the interaction under test from paced presses to key repeat, so it belongs in a separate change.

### How has this been tested?

Ran both suites locally against a real Chrome (chromedriver 151.0.7922.138, `npm run start:integ`): **20/20 pass**, including all 9 tests in `content-reordering.test.ts` since the shared page object changed.

Before switching `containsOptionsInOrder` to a batched read I verified the substitution is faithful, because `getText()` and script-based text reads differ for elements outside the viewport — a hazard the existing `expectAnnouncement` comment in that same file already calls out. A probe on the 50-option list compared per-element `getText()` against batched `innerText` and `textContent`:

- identical arrays for all three, both before and after scrolling the list to position 31
- zero empty entries from `getText()` after scrolling, so the viewport hazard does not apply on this page
- 282 ms → 4 ms for the read itself locally