### PR TITLE
chore: skip one-theme-only css if theme is excluded

### DIFF
--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -106,7 +106,7 @@ $dropdown-trigger-icon-offset: 2px;
     }
 
     &.has-trigger-text {
-      /* the component sets this class in every theme, the rules below apply in one theme only */
+      /* this comment keeps the class in the style sheet */
       @include theming.one-theme-only {
         & > .trigger-button {
           padding-inline: calc(#{awsui.$space-xs} + #{$dropdown-trigger-icon-offset});

--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -105,17 +105,20 @@ $dropdown-trigger-icon-offset: 2px;
       }
     }
 
+    &.has-trigger-text {
+      /* the component sets this class in every theme, the rules below apply in one theme only */
+      @include theming.one-theme-only {
+        & > .trigger-button {
+          padding-inline: calc(#{awsui.$space-xs} + #{$dropdown-trigger-icon-offset});
+        }
+      }
+    }
+
     @include theming.one-theme-only {
       & > .trigger-button {
         // Resets the padding-inline-end override applied by .visual-refresh above,
         // so both sides stay at $space-xs - $dropdown-trigger-icon-offset.
         padding-inline: calc(#{awsui.$space-xs} - #{$dropdown-trigger-icon-offset});
-      }
-
-      &.has-trigger-text {
-        & > .trigger-button {
-          padding-inline: calc(#{awsui.$space-xs} + #{$dropdown-trigger-icon-offset});
-        }
       }
     }
   }

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -325,6 +325,7 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
 
 // One-theme only: inner wrapper that collapses to 0 height via the grid-row track.
 .content-inner {
+  /* the component sets this class in every theme, the rules below apply in one theme only */
   @include theming.one-theme-only {
     // overflow: visible lets negative-margin backgrounds (e.g. side-navigation
     // active/hover/focus states) bleed past the inline edges.
@@ -338,20 +339,26 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
     @include styles.with-motion {
       transition: opacity $reveal-exit-motion;
     }
+  }
+}
 
-    &-expanded {
-      opacity: 1;
+.content-inner-expanded {
+  /* the component sets this class in every theme, the rules below apply in one theme only */
+  @include theming.one-theme-only {
+    opacity: 1;
 
-      // SHOW (expanded state): opacity fades in AFTER height has partially
-      // opened, creating a perceptible fade in the revealed space.
-      @include styles.with-motion {
-        transition: opacity $reveal-enter-delayed-motion;
-      }
+    // SHOW (expanded state): opacity fades in AFTER height has partially
+    // opened, creating a perceptible fade in the revealed space.
+    @include styles.with-motion {
+      transition: opacity $reveal-enter-delayed-motion;
     }
+  }
+}
 
-    &-settled {
-      overflow-y: visible;
-    }
+.content-inner-settled {
+  /* the component sets this class in every theme, the rules below apply in one theme only */
+  @include theming.one-theme-only {
+    overflow-y: visible;
   }
 }
 

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -325,7 +325,7 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
 
 // One-theme only: inner wrapper that collapses to 0 height via the grid-row track.
 .content-inner {
-  /* the component sets this class in every theme, the rules below apply in one theme only */
+  /* this comment keeps the class in the style sheet */
   @include theming.one-theme-only {
     // overflow: visible lets negative-margin backgrounds (e.g. side-navigation
     // active/hover/focus states) bleed past the inline edges.
@@ -343,7 +343,7 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
 }
 
 .content-inner-expanded {
-  /* the component sets this class in every theme, the rules below apply in one theme only */
+  /* this comment keeps the class in the style sheet */
   @include theming.one-theme-only {
     opacity: 1;
 
@@ -356,7 +356,7 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
 }
 
 .content-inner-settled {
-  /* the component sets this class in every theme, the rules below apply in one theme only */
+  /* this comment keeps the class in the style sheet */
   @include theming.one-theme-only {
     overflow-y: visible;
   }

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -170,7 +170,7 @@
 // Inside an expandable section (one-theme), tighten the heading's top padding by the button's
 // top and bottom border widths so it aligns with the button content box.
 .title-variant-h2.title-in-expandable-section {
-  /* the component sets this class in every theme, the rule below applies in one theme only */
+  /* this comment keeps the class in the style sheet */
   @include theming.one-theme-only {
     padding-block-start: calc(
       #{space-heading-button-diff(awsui.$line-height-heading-l)} - 2 * #{awsui.$border-width-button}

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -170,6 +170,7 @@
 // Inside an expandable section (one-theme), tighten the heading's top padding by the button's
 // top and bottom border widths so it aligns with the button content box.
 .title-variant-h2.title-in-expandable-section {
+  /* the component sets this class in every theme, the rule below applies in one theme only */
   @include theming.one-theme-only {
     padding-block-start: calc(
       #{space-heading-button-diff(awsui.$line-height-heading-l)} - 2 * #{awsui.$border-width-button}

--- a/src/internal/styles/utils/theming.scss
+++ b/src/internal/styles/utils/theming.scss
@@ -2,6 +2,9 @@
  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 */
+@use 'sass:map';
+@use 'awsui:resolved-tokens' as resolved-tokens;
+
 @mixin dark-mode-only($selector: '') {
   @media not print {
     /* stylelint-disable selector-combinator-disallowed-list, selector-class-pattern */
@@ -13,7 +16,12 @@
 }
 
 @mixin one-theme-only($selector: '') {
-  :global(#{$selector}.awsui-one-theme) & {
-    @content;
+  // When One Theme is not part of the components these selectors are not emitted.
+  @each $theme in resolved-tokens.$resolved-tokens {
+    @if map.get($theme, 'selector') == '.awsui-one-theme' {
+      :global(#{$selector}.awsui-one-theme) & {
+        @content;
+      }
+    }
   }
 }

--- a/src/tree-view/tree-item/styles.scss
+++ b/src/tree-view/tree-item/styles.scss
@@ -51,7 +51,7 @@ $item-toggle-column-width: 28px;
     }
 
     &.with-icon {
-      /* the component sets this class in every theme, the rules below apply in one theme only */
+      /* this comment keeps the class in the style sheet */
       @include theming.one-theme-only {
         align-items: baseline;
         > .expand-toggle-wrapper > .toggle {

--- a/src/tree-view/tree-item/styles.scss
+++ b/src/tree-view/tree-item/styles.scss
@@ -50,18 +50,21 @@ $item-toggle-column-width: 28px;
       }
     }
 
+    &.with-icon {
+      /* the component sets this class in every theme, the rules below apply in one theme only */
+      @include theming.one-theme-only {
+        align-items: baseline;
+        > .expand-toggle-wrapper > .toggle {
+          inset-block-start: 2px;
+        }
+      }
+    }
+
     @include theming.one-theme-only {
       align-items: center;
       > .expand-toggle-wrapper > .toggle {
         inset-inline-start: 0px;
         inset-block-start: 3px;
-      }
-
-      &.with-icon {
-        align-items: baseline;
-        > .expand-toggle-wrapper > .toggle {
-          inset-block-start: 2px;
-        }
       }
     }
 


### PR DESCRIPTION
### Description

Some one theme related styling made it into builds that don't include one theme.

The one-theme-only mixin emitted its selectors all the time, including builds that leave one theme out.

This PR gates the mixin on the themes listed in awsui:resolved-tokens. Output is byte-identical when one theme is included, and scoped CSS drops when it is not. Pretty cool.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
