### PR TITLE
fix: Meet 3:1 contrast for readonly search icon and button loading sp…

### DIFF
--- a/src/button/icon-helper.tsx
+++ b/src/button/icon-helper.tsx
@@ -49,7 +49,7 @@ function IconWrapper({ iconName, iconUrl, iconAlt, iconSvg, iconSize, badge, ...
 
 export function LeftIcon(props: ButtonIconProps) {
   if (props.loading) {
-    return <InternalSpinner className={clsx(styles.icon, styles['icon-left'])} />;
+    return <InternalSpinner variant="disabled" className={clsx(styles.icon, styles['icon-left'])} />;
   } else if (getIconAlign(props) === 'left') {
     return <IconWrapper {...props} />;
   }

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -296,7 +296,7 @@ function InternalInput(
     >
       {__startIcon && (
         <span onClick={__onStartIconClick} className={styles['input-icon-start']}>
-          <InternalIcon name={__startIcon} variant={disabled || readOnly ? 'disabled' : __startIconVariant} />
+          <InternalIcon name={__startIcon} variant={disabled ? 'disabled' : readOnly ? 'subtle' : __startIconVariant} />
         </span>
       )}
       {hasPrefixOrSuffix ? (

--- a/src/spinner/mixins.scss
+++ b/src/spinner/mixins.scss
@@ -30,7 +30,7 @@ $_spinner-sizes: (
 
 $_spinner-variants: (
   'normal': currentColor,
-  'disabled': awsui.$color-text-interactive-disabled,
+  'disabled': awsui.$color-text-status-inactive,
   'inverted': awsui.$color-text-inverted,
 );
 

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -62,11 +62,9 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundButtonPrimaryDefault: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
   colorBackgroundButtonPrimaryHover: { light: '{colorNeutral700}', dark: '{colorNeutral200}' },
   colorBackgroundButtonPrimaryActive: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
-  colorBackgroundButtonPrimaryDisabled: { light: '{colorNeutral150}', dark: '{colorNeutral700}' },
   colorTextButtonPrimaryDefault: { light: '{colorNeutral100}', dark: '{colorNeutral950}' },
   colorTextButtonPrimaryHover: { light: '{colorNeutral50}', dark: '{colorNeutral950}' },
   colorTextButtonPrimaryActive: { light: '{colorNeutral50}', dark: '{colorNeutral950}' },
-  colorTextButtonPrimaryDisabled: { light: '{colorNeutral500}', dark: '{colorNeutral950}' },
 
   // ── Toggle button ─────────────────────────────────────────────────────────
   colorBackgroundToggleButtonNormalPressed: { light: '{colorWhite}', dark: '{colorNeutral1000}' },
@@ -182,7 +180,6 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextStatusSuccess: { light: '{colorSuccess600}', dark: '{colorSuccess200}' },
   colorTextStatusWarning: { light: '{colorWarning900}', dark: '{colorWarning300}' },
   colorTextStatusError: { light: '{colorError600}', dark: '{colorError400}' },
-  colorTextStatusInactive: { light: '{colorNeutral650}', dark: '{colorNeutral450}' },
 
   // ── Dropdown & Popover ─────────────────────────────────────────────────
   colorTextDropdownItemFilterMatch: { light: '{colorPrimary600}', dark: '{colorPrimary500}' },
@@ -197,7 +194,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundStatusIndicatorWarning: { light: '{colorWarning50}', dark: '#fbd33220' },
   colorBackgroundStatusIndicatorSuccess: { light: '{colorSuccess50}', dark: '#2bb53420' },
   colorBackgroundStatusIndicatorError: { light: '{colorError50}', dark: '#ff7a7a20' },
-  colorBackgroundStatusIndicatorNeutral: { light: '{colorNeutral250}', dark: '{colorNeutral800}' },
+  colorBackgroundStatusIndicatorNeutral: { light: '{colorNeutral200}', dark: '{colorNeutral800}' },
 
   // ── Table ─────────────────────────────────────────────────────────────────
   colorBackgroundCellShaded: { light: '{colorNeutral150}', dark: '{colorNeutral900}' },


### PR DESCRIPTION
THIS IS A TEST IN DRAFT BY ME NOT TO BE REVIEWED 




Gray graphical elements essential for understanding failed WCAG 1.4.11 (non-text contrast) in one-theme with a 2.00:1 ratio (#b7b7b7 on white):

- Read-only search inputs rendered the magnifying glass icon with the disabled icon variant; use the subtle variant in readonly state so it keeps sufficient contrast (disabled state is unchanged).
- Loading spinners in buttons inherited the disabled text color; give the button spinner the disabled spinner variant and point that variant at colorTextStatusInactive, which meets contrast in all themes.
- Align one-theme button a11y tokens per design guidance: colorTextStatusInactive, colorBackgroundButtonPrimaryDisabled and colorTextButtonPrimaryDisabled now fall back to the visual-refresh assignments; colorBackgroundStatusIndicatorNeutral light moves from neutral-250 to neutral-200.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
