### PR TITLE
fix: Improve disabled button spinner and readonly input icon contrast

### DIFF
--- a/src/button/icon-helper.tsx
+++ b/src/button/icon-helper.tsx
@@ -49,7 +49,7 @@ function IconWrapper({ iconName, iconUrl, iconAlt, iconSvg, iconSize, badge, ...
 
 export function LeftIcon(props: ButtonIconProps) {
   if (props.loading) {
-    return <InternalSpinner className={clsx(styles.icon, styles['icon-left'])} />;
+    return <InternalSpinner variant="disabled" className={clsx(styles.icon, styles['icon-left'])} />;
   } else if (getIconAlign(props) === 'left') {
     return <IconWrapper {...props} />;
   }

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -296,7 +296,7 @@ function InternalInput(
     >
       {__startIcon && (
         <span onClick={__onStartIconClick} className={styles['input-icon-start']}>
-          <InternalIcon name={__startIcon} variant={disabled || readOnly ? 'disabled' : __startIconVariant} />
+          <InternalIcon name={__startIcon} variant={disabled ? 'disabled' : readOnly ? 'subtle' : __startIconVariant} />
         </span>
       )}
       {hasPrefixOrSuffix ? (

--- a/src/spinner/mixins.scss
+++ b/src/spinner/mixins.scss
@@ -30,7 +30,7 @@ $_spinner-sizes: (
 
 $_spinner-variants: (
   'normal': currentColor,
-  'disabled': awsui.$color-text-interactive-disabled,
+  'disabled': awsui.$color-text-status-inactive,
   'inverted': awsui.$color-text-inverted,
 );
 

--- a/style-dictionary/one-theme/colors.ts
+++ b/style-dictionary/one-theme/colors.ts
@@ -62,11 +62,9 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundButtonPrimaryDefault: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
   colorBackgroundButtonPrimaryHover: { light: '{colorNeutral700}', dark: '{colorNeutral200}' },
   colorBackgroundButtonPrimaryActive: { light: '{colorNeutral800}', dark: '{colorNeutral300}' },
-  colorBackgroundButtonPrimaryDisabled: { light: '{colorNeutral150}', dark: '{colorNeutral700}' },
   colorTextButtonPrimaryDefault: { light: '{colorNeutral100}', dark: '{colorNeutral950}' },
   colorTextButtonPrimaryHover: { light: '{colorNeutral50}', dark: '{colorNeutral950}' },
   colorTextButtonPrimaryActive: { light: '{colorNeutral50}', dark: '{colorNeutral950}' },
-  colorTextButtonPrimaryDisabled: { light: '{colorNeutral500}', dark: '{colorNeutral950}' },
 
   // ── Toggle button ─────────────────────────────────────────────────────────
   colorBackgroundToggleButtonNormalPressed: { light: '{colorWhite}', dark: '{colorNeutral1000}' },
@@ -182,7 +180,6 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextStatusSuccess: { light: '{colorSuccess600}', dark: '{colorSuccess200}' },
   colorTextStatusWarning: { light: '{colorWarning900}', dark: '{colorWarning300}' },
   colorTextStatusError: { light: '{colorError600}', dark: '{colorError400}' },
-  colorTextStatusInactive: { light: '{colorNeutral650}', dark: '{colorNeutral450}' },
 
   // ── Dropdown & Popover ─────────────────────────────────────────────────
   colorTextDropdownItemFilterMatch: { light: '{colorPrimary600}', dark: '{colorPrimary500}' },
@@ -197,7 +194,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundStatusIndicatorWarning: { light: '{colorWarning50}', dark: '#fbd33220' },
   colorBackgroundStatusIndicatorSuccess: { light: '{colorSuccess50}', dark: '#2bb53420' },
   colorBackgroundStatusIndicatorError: { light: '{colorError50}', dark: '#ff7a7a20' },
-  colorBackgroundStatusIndicatorNeutral: { light: '{colorNeutral250}', dark: '{colorNeutral800}' },
+  colorBackgroundStatusIndicatorNeutral: { light: '{colorNeutral200}', dark: '{colorNeutral800}' },
 
   // ── Table ─────────────────────────────────────────────────────────────────
   colorBackgroundCellShaded: { light: '{colorNeutral150}', dark: '{colorNeutral900}' },


### PR DESCRIPTION
### Description
Accessibility improvements for disabled button spinner and readonly input icon

### Problem

- The spinner inside a disabled loading button uses a color token (colorTextInteractiveDisabled) that does not meet contrast requirements. A loading spinner is informational and should remain readable even in disabled state.
- The search icon in a readonly input uses variant="disabled", which has unnecessarily low contrast. Readonly inputs are still readable content and their icons should meet contrast.

### Changes

Component changes:
- **Button:** Pass variant="disabled" to the spinner when the button is in a disabled+loading state.
- **Spinner:** Update the disabled variant color from colorTextInteractiveDisabled to colorTextStatusInactive to meet contrast requirements.
- **Input:** Use variant="subtle" for the start icon when in readonly state instead of variant="disabled".

Token changes (one-theme):
- colorTextStatusInactive — fall back to visual-refresh assignment (light: neutral 650 → 600)
- colorBackgroundStatusIndicatorNeutral — light: neutral 250 → 200
- colorBackgroundButtonPrimaryDisabled — fall back to visual-refresh assignment (light: neutral 150 → 250, dark: neutral 700 → 750)
- colorTextButtonPrimaryDisabled — fall back to visual-refresh assignment (dark: neutral 950 → 500)

### How has this been tested?

- Screenshot tests run in dev pipeline to verify visual changes.
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
