### PR TITLE
feat: add theme opt-in gate for expressive motion

### DIFF
--- a/src/internal/styles/__tests__/expressive-motion-gate.test.ts
+++ b/src/internal/styles/__tests__/expressive-motion-gate.test.ts
@@ -14,21 +14,16 @@ const THEME_SELECTOR_A = 'body'; // theme A themes the whole document
 const THEME_SELECTOR_B = '.test-theme-a';
 const THEME_SELECTOR_C = '.test-theme-a-legacy:not(.test-theme-a)'; // substring-overlaps with theme B's selector
 const MODE_SELECTOR = '.test-reduce-motion';
+const KEYFRAMES = '@keyframes fade{from{opacity:0}}'; // what `compileKeyframes` emits when the gate opens
 
 function resolvedTokensStub(selectors: string[]) {
   return `$resolved-tokens: [${selectors.map(s => `(selector: "${s}", tokens: ())`).join(',\n')}];`;
 }
 
-/** Compiles `theming.scss` for an artefact containing `artefactThemes`. `optedIn` overrides `$expressive-motion-themes`. */
-function compile(artefactThemes: string[], optedIn?: string[]): string {
+/** Compiles `body` against `theming.scss` for an artefact containing `artefactThemes`. `optedIn` overrides `$expressive-motion-themes`. */
+function compileScss(body: string, artefactThemes: string[], optedIn?: string[]): string {
   const withClause = optedIn ? ` with ($expressive-motion-themes: (${optedIn.map(s => `'${s}'`).join(', ')},))` : '';
-  const source = `
-    @use 'theming' as theming${withClause};
-    .target {
-      @include theming.expressive-motion-only { color: red; }
-      @include theming.expressive-motion-only('${MODE_SELECTOR}') { animation: none; }
-    }
-  `;
+  const source = `@use 'theming' as theming${withClause};\n${body}`;
 
   return sass.compileString(source, {
     style: 'compressed',
@@ -57,6 +52,29 @@ function compile(artefactThemes: string[], optedIn?: string[]): string {
   }).css;
 }
 
+/** Compiles the `expressive-motion-only` mixin, both unguarded and guarded by `MODE_SELECTOR`. */
+function compileMixin(artefactThemes: string[], optedIn?: string[]): string {
+  return compileScss(
+    `.target {
+      @include theming.expressive-motion-only { color: red; }
+      @include theming.expressive-motion-only('${MODE_SELECTOR}') { animation: none; }
+    }`,
+    artefactThemes,
+    optedIn
+  );
+}
+
+/** Compiles `@keyframes` gated by the `has-expressive-motion` function, the other half of the opt-in gate. */
+function compileKeyframes(artefactThemes: string[], optedIn?: string[]): string {
+  return compileScss(
+    `@if theming.has-expressive-motion() {
+      @keyframes fade { from { opacity: 0; } }
+    }`,
+    artefactThemes,
+    optedIn
+  );
+}
+
 /** Renders the theme (plus `extraClasses`) on `<body>` with the target inside, and returns the target. */
 function renderTarget(theme: string, extraClasses: string[] = []): Element {
   document.body.className = '';
@@ -71,28 +89,32 @@ function renderTarget(theme: string, extraClasses: string[] = []): Element {
 
 describe('expressive-motion gate: opt-in', () => {
   test('emits nothing when the opted-in theme is absent from the artefact', () => {
-    expect(compile([THEME_SELECTOR_C, THEME_SELECTOR_A], [THEME_SELECTOR_B])).toBe('');
+    expect(compileMixin([THEME_SELECTOR_C, THEME_SELECTOR_A], [THEME_SELECTOR_B])).toBe('');
+    expect(compileKeyframes([THEME_SELECTOR_C, THEME_SELECTOR_A], [THEME_SELECTOR_B])).toBe('');
   });
 
   test('a substring-similar selector does not opt in by accident', () => {
-    expect(compile([THEME_SELECTOR_C], [THEME_SELECTOR_B])).toBe('');
+    expect(compileMixin([THEME_SELECTOR_C], [THEME_SELECTOR_B])).toBe('');
+    expect(compileKeyframes([THEME_SELECTOR_C], [THEME_SELECTOR_B])).toBe('');
   });
 
   test('emits exactly the themed + guarded rule per opted-in theme, nothing for a sibling that did not opt in', () => {
-    const css = compile([THEME_SELECTOR_A, THEME_SELECTOR_B, THEME_SELECTOR_C], [THEME_SELECTOR_A, THEME_SELECTOR_B]);
+    const artefact = [THEME_SELECTOR_A, THEME_SELECTOR_B, THEME_SELECTOR_C];
+    const optedIn = [THEME_SELECTOR_A, THEME_SELECTOR_B];
 
     // both opted-in themes share one rule per mixin call, and theme C appears nowhere
-    expect(css).toBe(
+    expect(compileMixin(artefact, optedIn)).toBe(
       `:global(${THEME_SELECTOR_A}) .target,:global(${THEME_SELECTOR_B}) .target{color:red}` +
         `:global(${THEME_SELECTOR_A}${MODE_SELECTOR}) .target,` +
         `:global(${THEME_SELECTOR_B}${MODE_SELECTOR}) .target{animation:none}`
     );
+    expect(compileKeyframes(artefact, optedIn)).toBe(KEYFRAMES);
   });
 });
 
 describe('expressive-motion gate: composition', () => {
   // `:global(...)` is a CSS-modules compile-time marker; strip it to get selectors a real DOM can match
-  const emitted = compile([THEME_SELECTOR_B, THEME_SELECTOR_A], [THEME_SELECTOR_B, THEME_SELECTOR_A]).replace(
+  const emitted = compileMixin([THEME_SELECTOR_B, THEME_SELECTOR_A], [THEME_SELECTOR_B, THEME_SELECTOR_A]).replace(
     /:global\(([^)]*)\)/g,
     '$1'
   );
@@ -120,8 +142,10 @@ describe('expressive-motion gate: composition', () => {
 describe('expressive-motion gate: default configuration', () => {
   test('ships with One Theme opted in by default (pin this if it ever changes intentionally)', () => {
     // One Theme is the shipped default
-    expect(compile(['.awsui-one-theme'])).not.toBe('');
+    expect(compileMixin(['.awsui-one-theme'])).not.toBe('');
+    expect(compileKeyframes(['.awsui-one-theme'])).toBe(KEYFRAMES);
     // any other theme has to opt in
-    expect(compile([THEME_SELECTOR_B])).toBe('');
+    expect(compileMixin([THEME_SELECTOR_B])).toBe('');
+    expect(compileKeyframes([THEME_SELECTOR_B])).toBe('');
   });
 });

--- a/src/internal/styles/__tests__/expressive-motion-gate.test.ts
+++ b/src/internal/styles/__tests__/expressive-motion-gate.test.ts
@@ -74,10 +74,6 @@ describe('expressive-motion gate: opt-in', () => {
     expect(compile([THEME_SELECTOR_C, THEME_SELECTOR_A], [THEME_SELECTOR_B])).toBe('');
   });
 
-  test('emits nothing when the artefact contains no themes at all', () => {
-    expect(compile([], [THEME_SELECTOR_B])).toBe('');
-  });
-
   test('a substring-similar selector does not opt in by accident', () => {
     expect(compile([THEME_SELECTOR_C], [THEME_SELECTOR_B])).toBe('');
   });

--- a/src/internal/styles/__tests__/expressive-motion-gate.test.ts
+++ b/src/internal/styles/__tests__/expressive-motion-gate.test.ts
@@ -1,0 +1,140 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as sass from 'sass';
+
+/**
+ * Regression tests for the expressive-motion theme opt-in gate.
+ *
+ * The gate once shipped with the mode selector concatenated BEFORE the theme selector.
+ * Since a theme selector can be an element (the primary theme's is `body`), that produced
+ * e.g. `.mode-offbody` — valid Sass, no warning, matches nothing, silently disabling the
+ * guard. Assertions here favour real DOM matching (`Element.matches`) over reading emitted
+ * CSS text, because that bug's selector was syntactically fine and still matched nothing.
+ *
+ * The gate has nothing to do with One Theme — it's just the first opt-in — so these use
+ * fictional theme selectors injected via `@use ... with (...)`. The one exception is the
+ * "default configuration" test at the bottom, which pins the real shipped value.
+ */
+
+const THEMING_SOURCE = fs.readFileSync(path.join(__dirname, '..', 'utils', 'theming.scss'), 'utf8');
+
+const THEME_A = '.test-theme-a';
+const THEME_B = 'body';
+const NOT_OPTED_IN = '.test-theme-a-legacy:not(.test-theme-a)';
+const MODE = '.test-mode-disabled';
+
+function resolvedTokensStub(selectors: string[]) {
+  return `$resolved-tokens: [${selectors.map(s => `(selector: "${s}", tokens: ())`).join(',\n')}];`;
+}
+
+/** Compiles `theming.scss` for an artefact containing `artefactThemes`. `optedIn` overrides
+ * `$expressive-motion-themes`; omit it to exercise the real shipped default instead. */
+function compile(artefactThemes: string[], optedIn?: string[]): string {
+  const withClause = optedIn ? ` with ($expressive-motion-themes: (${optedIn.map(s => `'${s}'`).join(', ')},))` : '';
+  const source = `
+    @use 'theming' as theming${withClause};
+    .target {
+      @include theming.expressive-motion-only { color: red; }
+      @include theming.expressive-motion-only('${MODE}') { animation: none; }
+    }
+  `;
+  const css = sass.compileString(source, {
+    importers: [
+      {
+        canonicalize(url: string) {
+          if (url === 'theming') {
+            return new URL('mem:theming');
+          }
+          return url.startsWith('awsui:') ? new URL(`awsui-stub:${url.slice('awsui:'.length)}`) : null;
+        },
+        load(canonicalUrl: URL) {
+          const contents = canonicalUrl.href === 'mem:theming' ? THEMING_SOURCE : resolvedTokensStub(artefactThemes);
+          return { contents, syntax: 'scss' as const };
+        },
+      },
+    ],
+  }).css;
+  return css.replace(/\/\*[\s\S]*?\*\//g, '').trim();
+}
+
+/** `:global(...)` is a CSS-modules compile-time marker; strip it to get a real selector. */
+function selectorsOf(css: string): string[] {
+  return Array.from(css.matchAll(/([^{}]+)\{/g))
+    .map(m => m[1].trim().replace(/:global\(([^)]*)\)/g, '$1'))
+    .filter(Boolean);
+}
+
+/** Renders `<body [classes]><div class="target"></div></body>` and returns the target. */
+function activate(theme: string, extraClasses: string[] = []): Element {
+  document.body.className = '';
+  document.body.innerHTML = '<div class="target"></div>';
+  const classes = [theme, ...extraClasses].filter(s => s.startsWith('.')).map(s => s.slice(1));
+  document.body.classList.add(...classes);
+  return document.querySelector('.target')!;
+}
+
+describe('expressive-motion gate: opt-in', () => {
+  test('emits nothing when no theme in the artefact has opted in', () => {
+    expect(compile([NOT_OPTED_IN, THEME_B], [THEME_A])).toBe('');
+  });
+
+  test('emits nothing when the artefact contains no themes at all', () => {
+    expect(compile([], [THEME_A])).toBe('');
+  });
+
+  test('a substring-similar selector does not opt in by accident', () => {
+    // NOT_OPTED_IN contains THEME_A as a literal substring; list membership must be
+    // equality-based, not a substring check, or this would wrongly match.
+    expect(compile([NOT_OPTED_IN], [THEME_A])).toBe('');
+  });
+
+  test('emits exactly the themed + guarded rule per opted-in theme, nothing for a sibling that did not opt in', () => {
+    const selectors = selectorsOf(compile([THEME_A, THEME_B, NOT_OPTED_IN], [THEME_A, THEME_B]));
+    expect(selectors.filter(s => s.startsWith(THEME_A))).toHaveLength(2);
+    expect(selectors.filter(s => s.startsWith(THEME_B))).toHaveLength(2);
+    expect(selectors.some(s => s.includes('legacy'))).toBe(false);
+  });
+});
+
+describe.each([
+  ['class theme', THEME_A],
+  ['element theme', THEME_B],
+])('expressive-motion gate: %s composition', (_label, theme) => {
+  const selectors = selectorsOf(compile([THEME_A, THEME_B], [THEME_A, THEME_B]));
+  const guard = selectors.find(s => s.startsWith(`${theme}${MODE}`));
+  const themedOnly = selectors.find(s => s.startsWith(theme) && !s.includes(MODE));
+
+  test('theme selector composes before the mode selector, and the compound matches real DOM', () => {
+    expect(guard).toBeDefined();
+    expect(activate(theme, [MODE]).matches(guard!)).toBe(true);
+  });
+
+  test('the guard does not match when the mode is off', () => {
+    expect(activate(theme).matches(guard!)).toBe(false);
+  });
+
+  test('the theme-only rule matches when just the theme is present', () => {
+    expect(themedOnly).toBeDefined();
+    expect(activate(theme).matches(themedOnly!)).toBe(true);
+  });
+});
+
+test('the mode selector compounds onto the theme element, rather than nesting as a separate ancestor', () => {
+  const guard = selectorsOf(compile([THEME_A], [THEME_A])).find(s => s.startsWith(`${THEME_A}${MODE}`))!;
+  document.body.className = THEME_A.slice(1);
+  document.body.innerHTML = '';
+  const modeWrapper = document.createElement('div');
+  modeWrapper.className = MODE.slice(1);
+  modeWrapper.innerHTML = '<div class="target"></div>';
+  document.body.appendChild(modeWrapper);
+  expect(document.querySelector('.target')!.matches(guard)).toBe(false);
+});
+
+describe('expressive-motion gate: default configuration', () => {
+  test('ships with One Theme opted in by default (pin this if it ever changes intentionally)', () => {
+    expect(compile(['.awsui-one-theme'])).not.toBe('');
+    expect(compile([THEME_A])).toBe('');
+  });
+});

--- a/src/internal/styles/__tests__/expressive-motion-gate.test.ts
+++ b/src/internal/styles/__tests__/expressive-motion-gate.test.ts
@@ -70,7 +70,7 @@ function renderTarget(theme: string, extraClasses: string[] = []): Element {
 }
 
 describe('expressive-motion gate: opt-in', () => {
-  test('emits nothing when no theme in the artefact has opted in', () => {
+  test('emits nothing when the opted-in theme is absent from the artefact', () => {
     expect(compile([THEME_SELECTOR_C, THEME_SELECTOR_A], [THEME_SELECTOR_B])).toBe('');
   });
 

--- a/src/internal/styles/__tests__/expressive-motion-gate.test.ts
+++ b/src/internal/styles/__tests__/expressive-motion-gate.test.ts
@@ -57,33 +57,15 @@ function compile(artefactThemes: string[], optedIn?: string[]): string {
   }).css;
 }
 
-/** Returns list of selectors after stripping `:global(...)` */
-function selectorsOf(css: string): string[] {
-  return Array.from(css.matchAll(/([^{}]+)\{/g))
-    .map(m => m[1].trim().replace(/:global\(([^)]*)\)/g, '$1'))
-    .filter(Boolean);
-}
-
-/**
- * Renders the theme (plus `extraClasses`) on `<body>` with the target inside, and returns the target.
- * With `nestMode`, `extraClasses` go on a wrapper div between body and target instead.
- */
-function renderTarget(theme: string, extraClasses: string[] = [], nestMode = false): Element {
-  const classNames = (selectors: string[]) => selectors.filter(s => s.startsWith('.')).map(s => s.slice(1));
+/** Renders the theme (plus `extraClasses`) on `<body>` with the target inside, and returns the target. */
+function renderTarget(theme: string, extraClasses: string[] = []): Element {
   document.body.className = '';
   document.body.innerHTML = '';
-  document.body.classList.add(...classNames(nestMode ? [theme] : [theme, ...extraClasses]));
+  document.body.classList.add(...[theme, ...extraClasses].filter(s => s.startsWith('.')).map(s => s.slice(1)));
 
   const target = document.createElement('div');
   target.className = 'target';
-  let parent: Element = document.body;
-  if (nestMode) {
-    const wrapper = document.createElement('div');
-    wrapper.classList.add(...classNames(extraClasses));
-    document.body.appendChild(wrapper);
-    parent = wrapper;
-  }
-  parent.appendChild(target);
+  document.body.appendChild(target);
   return target;
 }
 
@@ -101,32 +83,34 @@ describe('expressive-motion gate: opt-in', () => {
   });
 
   test('emits exactly the themed + guarded rule per opted-in theme, nothing for a sibling that did not opt in', () => {
-    const selectors = selectorsOf(
-      compile([THEME_SELECTOR_A, THEME_SELECTOR_B, THEME_SELECTOR_C], [THEME_SELECTOR_A, THEME_SELECTOR_B])
-    );
+    const css = compile([THEME_SELECTOR_A, THEME_SELECTOR_B, THEME_SELECTOR_C], [THEME_SELECTOR_A, THEME_SELECTOR_B]);
 
-    expect(selectors.filter(s => s.startsWith(THEME_SELECTOR_A))).toHaveLength(2);
-    // each opted-in theme gets exactly its own pair of rules
-    expect(selectors.filter(s => s.startsWith(THEME_SELECTOR_B))).toHaveLength(2);
-    // a theme present in the artefact but not opted in gets nothing
-    expect(selectors.filter(s => s.startsWith(THEME_SELECTOR_C))).toHaveLength(0);
+    // both opted-in themes share one rule per mixin call, and theme C appears nowhere
+    expect(css).toBe(
+      `:global(${THEME_SELECTOR_A}) .target,:global(${THEME_SELECTOR_B}) .target{color:red}` +
+        `:global(${THEME_SELECTOR_A}${MODE_SELECTOR}) .target,` +
+        `:global(${THEME_SELECTOR_B}${MODE_SELECTOR}) .target{animation:none}`
+    );
   });
 });
 
 describe('expressive-motion gate: composition', () => {
-  const selectors = selectorsOf(compile([THEME_SELECTOR_B, THEME_SELECTOR_A], [THEME_SELECTOR_B, THEME_SELECTOR_A]));
+  // `:global(...)` is a CSS-modules compile-time marker; strip it to get selectors a real DOM can match
+  const emitted = compile([THEME_SELECTOR_B, THEME_SELECTOR_A], [THEME_SELECTOR_B, THEME_SELECTOR_A]).replace(
+    /:global\(([^)]*)\)/g,
+    '$1'
+  );
 
   test.each([
     ['element selector theme (A)', THEME_SELECTOR_A],
     ['class selector theme (B)', THEME_SELECTOR_B],
   ])('%s: emitted selectors match the real DOM only under the right conditions', (_label, theme) => {
-    const themeRule = `${theme} .target`; // .target comes from the scss definition above
+    const themeRule = `${theme} .target`;
     const modeRule = `${theme}${MODE_SELECTOR} .target`;
 
-    // the mixin emits the unguarded rule for an opted-in theme
-    expect(selectors).toContain(themeRule);
-    // and the guarded rule, with the mode compounded onto the theme rather than nested under it
-    expect(selectors).toContain(modeRule);
+    // tie the assertions below to what the mixin actually emitted
+    expect(emitted).toContain(themeRule);
+    expect(emitted).toContain(modeRule);
 
     // the guarded rule applies once the mode is on
     expect(renderTarget(theme, [MODE_SELECTOR]).matches(modeRule)).toBe(true);
@@ -134,12 +118,6 @@ describe('expressive-motion gate: composition', () => {
     expect(renderTarget(theme).matches(modeRule)).toBe(false);
     // the unguarded rule applies on the theme alone
     expect(renderTarget(theme).matches(themeRule)).toBe(true);
-  });
-
-  test('the mode selector compounds onto the theme element, rather than nesting as a separate ancestor', () => {
-    const modeRule = `${THEME_SELECTOR_B}${MODE_SELECTOR} .target`;
-    // a mode class on a descendant must not satisfy the compound: both belong on the theme element
-    expect(renderTarget(THEME_SELECTOR_B, [MODE_SELECTOR], true).matches(modeRule)).toBe(false);
   });
 });
 

--- a/src/internal/styles/__tests__/expressive-motion-gate.test.ts
+++ b/src/internal/styles/__tests__/expressive-motion-gate.test.ts
@@ -6,135 +6,144 @@ import * as sass from 'sass';
 
 /**
  * Regression tests for the expressive-motion theme opt-in gate.
- *
- * The gate once shipped with the mode selector concatenated BEFORE the theme selector.
- * Since a theme selector can be an element (the primary theme's is `body`), that produced
- * e.g. `.mode-offbody` — valid Sass, no warning, matches nothing, silently disabling the
- * guard. Assertions here favour real DOM matching (`Element.matches`) over reading emitted
- * CSS text, because that bug's selector was syntactically fine and still matched nothing.
- *
- * The gate has nothing to do with One Theme — it's just the first opt-in — so these use
- * fictional theme selectors injected via `@use ... with (...)`. The one exception is the
- * "default configuration" test at the bottom, which pins the real shipped value.
  */
 
 const THEMING_SOURCE = fs.readFileSync(path.join(__dirname, '..', 'utils', 'theming.scss'), 'utf8');
 
-const THEME_A = '.test-theme-a';
-const THEME_B = 'body';
-const NOT_OPTED_IN = '.test-theme-a-legacy:not(.test-theme-a)';
-const MODE = '.test-mode-disabled';
+const THEME_SELECTOR_A = 'body'; // theme A themes the whole document
+const THEME_SELECTOR_B = '.test-theme-a';
+const THEME_SELECTOR_C = '.test-theme-a-legacy:not(.test-theme-a)'; // substring-overlaps with theme B's selector
+const MODE_SELECTOR = '.test-mode-disabled';
 
 function resolvedTokensStub(selectors: string[]) {
   return `$resolved-tokens: [${selectors.map(s => `(selector: "${s}", tokens: ())`).join(',\n')}];`;
 }
 
-/** Compiles `theming.scss` for an artefact containing `artefactThemes`. `optedIn` overrides
- * `$expressive-motion-themes`; omit it to exercise the real shipped default instead. */
+/** Compiles `theming.scss` for an artefact containing `artefactThemes`. `optedIn` overrides `$expressive-motion-themes`. */
 function compile(artefactThemes: string[], optedIn?: string[]): string {
   const withClause = optedIn ? ` with ($expressive-motion-themes: (${optedIn.map(s => `'${s}'`).join(', ')},))` : '';
   const source = `
     @use 'theming' as theming${withClause};
     .target {
       @include theming.expressive-motion-only { color: red; }
-      @include theming.expressive-motion-only('${MODE}') { animation: none; }
+      @include theming.expressive-motion-only('${MODE_SELECTOR}') { animation: none; }
     }
   `;
-  const css = sass.compileString(source, {
+
+  return sass.compileString(source, {
+    style: 'compressed',
     importers: [
       {
         canonicalize(url: string) {
           if (url === 'theming') {
             return new URL('mem:theming');
           }
-          return url.startsWith('awsui:') ? new URL(`awsui-stub:${url.slice('awsui:'.length)}`) : null;
+          if (url === 'awsui:resolved-tokens') {
+            return new URL('mem:resolved-tokens');
+          }
+          return null;
         },
         load(canonicalUrl: URL) {
-          const contents = canonicalUrl.href === 'mem:theming' ? THEMING_SOURCE : resolvedTokensStub(artefactThemes);
-          return { contents, syntax: 'scss' as const };
+          if (canonicalUrl.href === 'mem:theming') {
+            return { contents: THEMING_SOURCE, syntax: 'scss' as const };
+          }
+          if (canonicalUrl.href === 'mem:resolved-tokens') {
+            return { contents: resolvedTokensStub(artefactThemes), syntax: 'scss' as const };
+          }
+          return null;
         },
       },
     ],
   }).css;
-  return css.replace(/\/\*[\s\S]*?\*\//g, '').trim();
 }
 
-/** `:global(...)` is a CSS-modules compile-time marker; strip it to get a real selector. */
+/** Returns list of selectors after stripping `:global(...)` */
 function selectorsOf(css: string): string[] {
   return Array.from(css.matchAll(/([^{}]+)\{/g))
     .map(m => m[1].trim().replace(/:global\(([^)]*)\)/g, '$1'))
     .filter(Boolean);
 }
 
-/** Renders `<body [classes]><div class="target"></div></body>` and returns the target. */
-function activate(theme: string, extraClasses: string[] = []): Element {
+/**
+ * Renders the theme (plus `extraClasses`) on `<body>` with the target inside, and returns the target.
+ * With `nestMode`, `extraClasses` go on a wrapper div between body and target instead.
+ */
+function renderTarget(theme: string, extraClasses: string[] = [], nestMode = false): Element {
+  const classNames = (selectors: string[]) => selectors.filter(s => s.startsWith('.')).map(s => s.slice(1));
   document.body.className = '';
-  document.body.innerHTML = '<div class="target"></div>';
-  const classes = [theme, ...extraClasses].filter(s => s.startsWith('.')).map(s => s.slice(1));
-  document.body.classList.add(...classes);
-  return document.querySelector('.target')!;
+  document.body.innerHTML = '';
+  document.body.classList.add(...classNames(nestMode ? [theme] : [theme, ...extraClasses]));
+
+  const target = document.createElement('div');
+  target.className = 'target';
+  let parent: Element = document.body;
+  if (nestMode) {
+    const wrapper = document.createElement('div');
+    wrapper.classList.add(...classNames(extraClasses));
+    document.body.appendChild(wrapper);
+    parent = wrapper;
+  }
+  parent.appendChild(target);
+  return target;
 }
 
 describe('expressive-motion gate: opt-in', () => {
   test('emits nothing when no theme in the artefact has opted in', () => {
-    expect(compile([NOT_OPTED_IN, THEME_B], [THEME_A])).toBe('');
+    expect(compile([THEME_SELECTOR_C, THEME_SELECTOR_A], [THEME_SELECTOR_B])).toBe('');
   });
 
   test('emits nothing when the artefact contains no themes at all', () => {
-    expect(compile([], [THEME_A])).toBe('');
+    expect(compile([], [THEME_SELECTOR_B])).toBe('');
   });
 
   test('a substring-similar selector does not opt in by accident', () => {
-    // NOT_OPTED_IN contains THEME_A as a literal substring; list membership must be
-    // equality-based, not a substring check, or this would wrongly match.
-    expect(compile([NOT_OPTED_IN], [THEME_A])).toBe('');
+    expect(compile([THEME_SELECTOR_C], [THEME_SELECTOR_B])).toBe('');
   });
 
   test('emits exactly the themed + guarded rule per opted-in theme, nothing for a sibling that did not opt in', () => {
-    const selectors = selectorsOf(compile([THEME_A, THEME_B, NOT_OPTED_IN], [THEME_A, THEME_B]));
-    expect(selectors.filter(s => s.startsWith(THEME_A))).toHaveLength(2);
-    expect(selectors.filter(s => s.startsWith(THEME_B))).toHaveLength(2);
-    expect(selectors.some(s => s.includes('legacy'))).toBe(false);
+    const selectors = selectorsOf(
+      compile([THEME_SELECTOR_A, THEME_SELECTOR_B, THEME_SELECTOR_C], [THEME_SELECTOR_A, THEME_SELECTOR_B])
+    );
+
+    expect(selectors.filter(s => s.startsWith(THEME_SELECTOR_A))).toHaveLength(2);
+    expect(selectors.filter(s => s.startsWith(THEME_SELECTOR_B))).toHaveLength(2);
+    expect(selectors.filter(s => s.startsWith(THEME_SELECTOR_C))).toHaveLength(0);
   });
 });
 
 describe.each([
-  ['class theme', THEME_A],
-  ['element theme', THEME_B],
+  ['element selector theme (A)', THEME_SELECTOR_A],
+  ['class selector theme (B)', THEME_SELECTOR_B],
 ])('expressive-motion gate: %s composition', (_label, theme) => {
-  const selectors = selectorsOf(compile([THEME_A, THEME_B], [THEME_A, THEME_B]));
-  const guard = selectors.find(s => s.startsWith(`${theme}${MODE}`));
-  const themedOnly = selectors.find(s => s.startsWith(theme) && !s.includes(MODE));
+  const selectors = selectorsOf(compile([THEME_SELECTOR_B, THEME_SELECTOR_A], [THEME_SELECTOR_B, THEME_SELECTOR_A]));
+  const guard = selectors.find(s => s.startsWith(`${theme}${MODE_SELECTOR}`));
+  const themedOnly = selectors.find(s => s.startsWith(theme) && !s.includes(MODE_SELECTOR));
 
   test('theme selector composes before the mode selector, and the compound matches real DOM', () => {
     expect(guard).toBeDefined();
-    expect(activate(theme, [MODE]).matches(guard!)).toBe(true);
+    expect(renderTarget(theme, [MODE_SELECTOR]).matches(guard!)).toBe(true);
   });
 
   test('the guard does not match when the mode is off', () => {
-    expect(activate(theme).matches(guard!)).toBe(false);
+    expect(renderTarget(theme).matches(guard!)).toBe(false);
   });
 
   test('the theme-only rule matches when just the theme is present', () => {
     expect(themedOnly).toBeDefined();
-    expect(activate(theme).matches(themedOnly!)).toBe(true);
+    expect(renderTarget(theme).matches(themedOnly!)).toBe(true);
   });
 });
 
 test('the mode selector compounds onto the theme element, rather than nesting as a separate ancestor', () => {
-  const guard = selectorsOf(compile([THEME_A], [THEME_A])).find(s => s.startsWith(`${THEME_A}${MODE}`))!;
-  document.body.className = THEME_A.slice(1);
-  document.body.innerHTML = '';
-  const modeWrapper = document.createElement('div');
-  modeWrapper.className = MODE.slice(1);
-  modeWrapper.innerHTML = '<div class="target"></div>';
-  document.body.appendChild(modeWrapper);
-  expect(document.querySelector('.target')!.matches(guard)).toBe(false);
+  const guard = selectorsOf(compile([THEME_SELECTOR_B], [THEME_SELECTOR_B])).find(s =>
+    s.startsWith(`${THEME_SELECTOR_B}${MODE_SELECTOR}`)
+  )!;
+  expect(renderTarget(THEME_SELECTOR_B, [MODE_SELECTOR], true).matches(guard)).toBe(false);
 });
 
 describe('expressive-motion gate: default configuration', () => {
   test('ships with One Theme opted in by default (pin this if it ever changes intentionally)', () => {
     expect(compile(['.awsui-one-theme'])).not.toBe('');
-    expect(compile([THEME_A])).toBe('');
+    expect(compile([THEME_SELECTOR_B])).toBe('');
   });
 });

--- a/src/internal/styles/__tests__/expressive-motion-gate.test.ts
+++ b/src/internal/styles/__tests__/expressive-motion-gate.test.ts
@@ -13,7 +13,7 @@ const THEMING_SOURCE = fs.readFileSync(path.join(__dirname, '..', 'utils', 'them
 const THEME_SELECTOR_A = 'body'; // theme A themes the whole document
 const THEME_SELECTOR_B = '.test-theme-a';
 const THEME_SELECTOR_C = '.test-theme-a-legacy:not(.test-theme-a)'; // substring-overlaps with theme B's selector
-const MODE_SELECTOR = '.test-mode-disabled';
+const MODE_SELECTOR = '.test-reduce-motion';
 
 function resolvedTokensStub(selectors: string[]) {
   return `$resolved-tokens: [${selectors.map(s => `(selector: "${s}", tokens: ())`).join(',\n')}];`;
@@ -106,44 +106,48 @@ describe('expressive-motion gate: opt-in', () => {
     );
 
     expect(selectors.filter(s => s.startsWith(THEME_SELECTOR_A))).toHaveLength(2);
+    // each opted-in theme gets exactly its own pair of rules
     expect(selectors.filter(s => s.startsWith(THEME_SELECTOR_B))).toHaveLength(2);
+    // a theme present in the artefact but not opted in gets nothing
     expect(selectors.filter(s => s.startsWith(THEME_SELECTOR_C))).toHaveLength(0);
   });
 });
 
-describe.each([
-  ['element selector theme (A)', THEME_SELECTOR_A],
-  ['class selector theme (B)', THEME_SELECTOR_B],
-])('expressive-motion gate: %s composition', (_label, theme) => {
+describe('expressive-motion gate: composition', () => {
   const selectors = selectorsOf(compile([THEME_SELECTOR_B, THEME_SELECTOR_A], [THEME_SELECTOR_B, THEME_SELECTOR_A]));
-  const guard = selectors.find(s => s.startsWith(`${theme}${MODE_SELECTOR}`));
-  const themedOnly = selectors.find(s => s.startsWith(theme) && !s.includes(MODE_SELECTOR));
 
-  test('theme selector composes before the mode selector, and the compound matches real DOM', () => {
-    expect(guard).toBeDefined();
-    expect(renderTarget(theme, [MODE_SELECTOR]).matches(guard!)).toBe(true);
+  test.each([
+    ['element selector theme (A)', THEME_SELECTOR_A],
+    ['class selector theme (B)', THEME_SELECTOR_B],
+  ])('%s: emitted selectors match the real DOM only under the right conditions', (_label, theme) => {
+    const themeRule = `${theme} .target`; // .target comes from the scss definition above
+    const modeRule = `${theme}${MODE_SELECTOR} .target`;
+
+    // the mixin emits the unguarded rule for an opted-in theme
+    expect(selectors).toContain(themeRule);
+    // and the guarded rule, with the mode compounded onto the theme rather than nested under it
+    expect(selectors).toContain(modeRule);
+
+    // the guarded rule applies once the mode is on
+    expect(renderTarget(theme, [MODE_SELECTOR]).matches(modeRule)).toBe(true);
+    // but must not leak when the mode is off, otherwise the guard argument is being ignored
+    expect(renderTarget(theme).matches(modeRule)).toBe(false);
+    // the unguarded rule applies on the theme alone
+    expect(renderTarget(theme).matches(themeRule)).toBe(true);
   });
 
-  test('the guard does not match when the mode is off', () => {
-    expect(renderTarget(theme).matches(guard!)).toBe(false);
+  test('the mode selector compounds onto the theme element, rather than nesting as a separate ancestor', () => {
+    const modeRule = `${THEME_SELECTOR_B}${MODE_SELECTOR} .target`;
+    // a mode class on a descendant must not satisfy the compound: both belong on the theme element
+    expect(renderTarget(THEME_SELECTOR_B, [MODE_SELECTOR], true).matches(modeRule)).toBe(false);
   });
-
-  test('the theme-only rule matches when just the theme is present', () => {
-    expect(themedOnly).toBeDefined();
-    expect(renderTarget(theme).matches(themedOnly!)).toBe(true);
-  });
-});
-
-test('the mode selector compounds onto the theme element, rather than nesting as a separate ancestor', () => {
-  const guard = selectorsOf(compile([THEME_SELECTOR_B], [THEME_SELECTOR_B])).find(s =>
-    s.startsWith(`${THEME_SELECTOR_B}${MODE_SELECTOR}`)
-  )!;
-  expect(renderTarget(THEME_SELECTOR_B, [MODE_SELECTOR], true).matches(guard)).toBe(false);
 });
 
 describe('expressive-motion gate: default configuration', () => {
   test('ships with One Theme opted in by default (pin this if it ever changes intentionally)', () => {
+    // One Theme is the shipped default
     expect(compile(['.awsui-one-theme'])).not.toBe('');
+    // any other theme has to opt in
     expect(compile([THEME_SELECTOR_B])).toBe('');
   });
 });

--- a/src/internal/styles/utils/theming.scss
+++ b/src/internal/styles/utils/theming.scss
@@ -29,7 +29,7 @@
   }
 }
 
-$expressive-motion-themes: ('.awsui-one-theme',) !default;
+$expressive-motion-themes: list.append((), '.awsui-one-theme') !default;
 
 /// Two ways to gate on the opt-in above:
 /// - a function `has-expressive-motion` used to wrap `@keyframes`

--- a/src/internal/styles/utils/theming.scss
+++ b/src/internal/styles/utils/theming.scss
@@ -38,14 +38,19 @@ $expressive-motion-themes: ('.awsui-one-theme') !default;
   @return false;
 }
 
-/// Emits `@content` once per opted-in theme, scoped to that theme's selector.
+/// Emits `@content` once, scoped to every opted-in theme's selector.
 @mixin expressive-motion-only($selector: '') {
+  $selectors: ();
   @each $theme in resolved-tokens.$resolved-tokens {
     $theme-selector: string.unquote(map.get($theme, 'selector'));
     @if list.index($expressive-motion-themes, '#{$theme-selector}') {
-      :global(#{$theme-selector}#{$selector}) & {
-        @content;
-      }
+      $selectors: list.append($selectors, ':global(#{$theme-selector}#{$selector}) &', comma);
+    }
+  }
+  @if list.length($selectors) > 0 {
+    /* stylelint-disable-next-line @cloudscape-design/no-implicit-descendant -- every entry in the list already ends with `&` */
+    #{$selectors} {
+      @content;
     }
   }
 }

--- a/src/internal/styles/utils/theming.scss
+++ b/src/internal/styles/utils/theming.scss
@@ -23,7 +23,7 @@
   }
 }
 
-$expressive-motion-themes: ('.awsui-one-theme') !default;
+$expressive-motion-themes: ('.awsui-one-theme',) !default;
 
 /// Two ways to gate on the opt-in above:
 /// - a function `has-expressive-motion` used to wrap `@keyframes`

--- a/src/internal/styles/utils/theming.scss
+++ b/src/internal/styles/utils/theming.scss
@@ -23,19 +23,12 @@
   }
 }
 
-/// Themes that opt in to expressive motion, by selector. An explicit list, not a design
-/// token — tokens carry style values, not feature switches. `!default` so tests can
-/// override it with fictional themes.
 $expressive-motion-themes: ('.awsui-one-theme') !default;
 
-/// Two ways to gate on the opt-in above, because one consumer shape can't use a selector
-/// wrapper: `@keyframes` cannot nest inside a selector, so `hover-motion.scss` (a later
-/// PR) needs a plain build-time boolean to decide whether to emit its top-level
-/// `@keyframes` block at all — which is also what keeps a non-opted-in artefact free of
-/// keyframe bytes. `expressive-motion-only()` below is the wrapper form for everything
-/// else: content that already lives inside a selector.
+/// Two ways to gate on the opt-in above:
+/// - a function `has-expressive-motion` used to wrap `@keyframes`
+/// - a mixin `expressive-motion-only` is the wrapper form for everything
 
-/// True if any theme in this artefact's `$resolved-tokens` has opted in.
 @function has-expressive-motion() {
   @each $theme in resolved-tokens.$resolved-tokens {
     @if list.index($expressive-motion-themes, '#{string.unquote(map.get($theme, 'selector'))}') {
@@ -45,19 +38,11 @@ $expressive-motion-themes: ('.awsui-one-theme') !default;
   @return false;
 }
 
-/// Emits `@content` once per opted-in theme, scoped to that theme's selector. Emits
-/// nothing for an artefact with no opted-in theme.
-///
-/// `$selector` compounds onto the theme selector (e.g. a mode class such as
-/// `.awsui-motion-disabled`) — for a caller that needs to combine the two.
+/// Emits `@content` once per opted-in theme, scoped to that theme's selector.
 @mixin expressive-motion-only($selector: '') {
   @each $theme in resolved-tokens.$resolved-tokens {
     $theme-selector: string.unquote(map.get($theme, 'selector'));
     @if list.index($expressive-motion-themes, '#{$theme-selector}') {
-      // Theme selector MUST come first: a theme selector isn't always a class (the
-      // primary theme's is the element `body`), so `$selector` first would concatenate
-      // e.g. `.awsui-motion-disabled` + `body` into `.awsui-motion-disabledbody` — valid
-      // Sass, silently unmatchable, and how the reduced-motion guards broke once already.
       :global(#{$theme-selector}#{$selector}) & {
         @content;
       }

--- a/src/internal/styles/utils/theming.scss
+++ b/src/internal/styles/utils/theming.scss
@@ -2,6 +2,11 @@
  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 */
+@use 'sass:list';
+@use 'sass:map';
+@use 'sass:string';
+@use 'awsui:resolved-tokens' as resolved-tokens;
+
 @mixin dark-mode-only($selector: '') {
   @media not print {
     /* stylelint-disable selector-combinator-disallowed-list, selector-class-pattern */
@@ -15,5 +20,47 @@
 @mixin one-theme-only($selector: '') {
   :global(#{$selector}.awsui-one-theme) & {
     @content;
+  }
+}
+
+/// Themes that opt in to expressive motion, by selector. An explicit list, not a design
+/// token — tokens carry style values, not feature switches. `!default` so tests can
+/// override it with fictional themes.
+$expressive-motion-themes: ('.awsui-one-theme') !default;
+
+/// Two ways to gate on the opt-in above, because one consumer shape can't use a selector
+/// wrapper: `@keyframes` cannot nest inside a selector, so `hover-motion.scss` (a later
+/// PR) needs a plain build-time boolean to decide whether to emit its top-level
+/// `@keyframes` block at all — which is also what keeps a non-opted-in artefact free of
+/// keyframe bytes. `expressive-motion-only()` below is the wrapper form for everything
+/// else: content that already lives inside a selector.
+
+/// True if any theme in this artefact's `$resolved-tokens` has opted in.
+@function has-expressive-motion() {
+  @each $theme in resolved-tokens.$resolved-tokens {
+    @if list.index($expressive-motion-themes, '#{string.unquote(map.get($theme, 'selector'))}') {
+      @return true;
+    }
+  }
+  @return false;
+}
+
+/// Emits `@content` once per opted-in theme, scoped to that theme's selector. Emits
+/// nothing for an artefact with no opted-in theme.
+///
+/// `$selector` compounds onto the theme selector (e.g. a mode class such as
+/// `.awsui-motion-disabled`) — for a caller that needs to combine the two.
+@mixin expressive-motion-only($selector: '') {
+  @each $theme in resolved-tokens.$resolved-tokens {
+    $theme-selector: string.unquote(map.get($theme, 'selector'));
+    @if list.index($expressive-motion-themes, '#{$theme-selector}') {
+      // Theme selector MUST come first: a theme selector isn't always a class (the
+      // primary theme's is the element `body`), so `$selector` first would concatenate
+      // e.g. `.awsui-motion-disabled` + `body` into `.awsui-motion-disabledbody` — valid
+      // Sass, silently unmatchable, and how the reduced-motion guards broke once already.
+      :global(#{$theme-selector}#{$selector}) & {
+        @content;
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description

Adds scss function and mixin for gating expressive motion rules on a theme basis. Adds tests for both.

Related links, issue #, if available: `b9VcPdMJ5zRn`

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
