### PR TITLE
fix: avoid emitting empty rule from block comment 

### DIFF
--- a/src/internal/styles/utils/theming.scss
+++ b/src/internal/styles/utils/theming.scss
@@ -54,7 +54,7 @@ $expressive-motion-themes: list.append((), '.awsui-one-theme') !default;
     }
   }
   @if list.length($selectors) > 0 {
-    /* stylelint-disable-next-line @cloudscape-design/no-implicit-descendant -- every entry in the list already ends with `&` */
+    // stylelint-disable-next-line @cloudscape-design/no-implicit-descendant -- every entry in the list already ends with `&`
     #{$selectors} {
       @content;
     }


### PR DESCRIPTION
### Description

TIL: Because `*/ ... /*` is CSS comment, it gets carried over wherease `//` is SASS only and will not end up in the output. Because of that, the `*/ ... /*` causes emission of empty rule blocks which we don't want in this case.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._



#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
