### PR TITLE
feat: add the icon hover-motion scaffolding and generic motion

### DIFF
--- a/src/icon/__tests__/icon-hover-motion.test.ts
+++ b/src/icon/__tests__/icon-hover-motion.test.ts
@@ -122,10 +122,6 @@ describe('the real built stylesheet', () => {
     expect(css).not.toMatch(/prefers-reduced-motion:\s*reduce\b/);
   });
 
-  test('no `@keyframes` are emitted', () => {
-    expect(fs.readFileSync(CSS_PATH, 'utf8')).not.toMatch(/@keyframes/);
-  });
-
   test('the floor also fires on :focus-visible, guarded the same way as :hover', () => {
     expect(genericRule().selectorText).toMatch(
       /\[data-awsui-motion-trigger~=hover]:not\(:disabled\):not\(\[aria-disabled=true]\):is\(:focus-visible,/

--- a/src/icon/__tests__/icon-hover-motion.test.ts
+++ b/src/icon/__tests__/icon-hover-motion.test.ts
@@ -4,12 +4,12 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as sass from 'sass';
 
-const HOVER_MOTION_SOURCE = fs.readFileSync(path.join(__dirname, '..', 'hover-motion.scss'), 'utf8');
-const THEMING_SOURCE = fs.readFileSync(
-  path.join(__dirname, '..', '..', 'internal', 'styles', 'utils', 'theming.scss'),
-  'utf8'
-);
-const CSS_PATH = path.join(__dirname, '..', '..', '..', 'lib', 'components', 'icon', 'styles.scoped.css');
+const SRC_ROOT = path.resolve(__dirname, '../..'); // .../src
+const BUILD_ROOT = path.resolve(SRC_ROOT, '../lib/components'); // .../lib/components
+
+const HOVER_MOTION_SOURCE = fs.readFileSync(path.join(SRC_ROOT, 'icon/hover-motion.scss'), 'utf8');
+const THEMING_SOURCE = fs.readFileSync(path.join(SRC_ROOT, 'internal/styles/utils/theming.scss'), 'utf8');
+const CSS_PATH = path.join(BUILD_ROOT, 'icon/styles.scoped.css');
 
 const THEME = '.awsui-one-theme';
 
@@ -21,9 +21,8 @@ const TOKENS_STUB = `
 `;
 
 /**
- * Compiles `hover-motion.scss` against the real `theming.scss`, for an artefact whose
- * `resolved-tokens` carry `optedInThemes`. dart-sass's filesystem importer crashes under
- * jest's jsdom environment, so every module is served from memory.
+ * Compiles `hover-motion.scss` against the real `theming.scss`, for an artefact
+ * whose `resolved-tokens` carry `optedInThemes`.
  */
 function compile(optedInThemes: string[]): string {
   return sass.compileString(`@use 'hover-motion' as hover-motion;\n@include hover-motion.icon-hover-motion;`, {
@@ -61,10 +60,7 @@ function compile(optedInThemes: string[]): string {
 }
 
 /**
- * Every style rule in the REAL built stylesheet, read through the CSSOM rather than a
- * bespoke selector parser — the browser's own parser already handles comma lists, `:is()`
- * and `@media` nesting correctly. The postcss `:not(#\\9)` specificity hack is stripped first:
- * it can never match an element, and jsdom's selector engine refuses to compile the escape.
+ * Every style rule in the REAL built stylesheet.
  */
 function builtRules(): CSSStyleRule[] {
   const style = document.createElement('style');
@@ -86,8 +82,10 @@ function builtRules(): CSSStyleRule[] {
   return rules;
 }
 
+// Icon-specific motions
 const hoverRules = () => builtRules().filter(rule => /:hover|:focus-visible/.test(rule.selectorText));
-const floorRule = () => hoverRules().find(rule => rule.style.transform === 'scale(0.94)')!;
+// Generic motion for icons that don't have their own motion
+const genericRule = () => hoverRules().find(rule => rule.style.transform === 'scale(0.94)')!;
 
 describe('the theme gate', () => {
   test('emits nothing for an artefact with no opted-in theme', () => {
@@ -106,15 +104,15 @@ describe('the theme gate', () => {
 
 describe('the real built stylesheet', () => {
   test('the floor rule carries the theme scope and both mode exclusions', () => {
-    expect(floorRule().selectorText).toContain(THEME);
-    expect(floorRule().selectorText).toContain(':not(.awsui-motion-disabled)');
-    expect(floorRule().selectorText).toContain(':not(.awsui-mode-entering)');
+    expect(genericRule().selectorText).toContain(THEME);
+    expect(genericRule().selectorText).toContain(':not(.awsui-motion-disabled)');
+    expect(genericRule().selectorText).toContain(':not(.awsui-mode-entering)');
   });
 
   test('the floor targets the INNER svg, never the outer .icon span', () => {
-    expect(floorRule().style.transform).toBe('scale(0.94)');
+    expect(genericRule().style.transform).toBe('scale(0.94)');
     // The rule's target is the last compound; it must be the opted-in svg, not a bare `.icon`.
-    const target = floorRule().selectorText.split(/\s+/).pop()!;
+    const target = genericRule().selectorText.split(/\s+/).pop()!;
     expect(target).toMatch(/^>?\s*svg\[data-awsui-icon-animated\]$/);
   });
 
@@ -129,7 +127,7 @@ describe('the real built stylesheet', () => {
   });
 
   test('the floor also fires on :focus-visible, guarded the same way as :hover', () => {
-    expect(floorRule().selectorText).toMatch(
+    expect(genericRule().selectorText).toMatch(
       /\[data-awsui-motion-trigger~=hover]:not\(:disabled\):not\(\[aria-disabled=true]\):is\(:focus-visible,/
     );
   });
@@ -138,7 +136,7 @@ describe('the real built stylesheet', () => {
     // The region is the one compound immediately left of `:hover` — an ancestor theme scope
     // sits further left, joined by a descendant combinator, so it must not be included: a
     // bare region element has no such ancestor and would otherwise never match.
-    const selector = floorRule().selectorText;
+    const selector = genericRule().selectorText;
     const hoverIndex = selector.indexOf(':hover');
     const regionStart = selector.lastIndexOf(' ', hoverIndex) + 1;
     const region = selector.slice(regionStart, hoverIndex);

--- a/src/icon/__tests__/icon-hover-motion.test.ts
+++ b/src/icon/__tests__/icon-hover-motion.test.ts
@@ -5,11 +5,9 @@ import * as path from 'node:path';
 import * as sass from 'sass';
 
 const SRC_ROOT = path.resolve(__dirname, '../..'); // .../src
-const BUILD_ROOT = path.resolve(SRC_ROOT, '../lib/components'); // .../lib/components
 
 const HOVER_MOTION_SOURCE = fs.readFileSync(path.join(SRC_ROOT, 'icon/hover-motion.scss'), 'utf8');
 const THEMING_SOURCE = fs.readFileSync(path.join(SRC_ROOT, 'internal/styles/utils/theming.scss'), 'utf8');
-const CSS_PATH = path.join(BUILD_ROOT, 'icon/styles.scoped.css');
 
 const THEME = '.awsui-one-theme';
 
@@ -49,33 +47,17 @@ function compile(optedInThemes: string[]): string {
 }
 
 /**
- * Parses the built stylesheet into real CSSStyleRule objects, so tests can
- * assert on selectorText and style instead of matching raw CSS text.
+ * The selector of the generic hover-motion rule (the one setting `scale(0.94)`),
+ * compiled with `THEME` opted in.
  */
-function builtRules(): CSSStyleRule[] {
-  const style = document.createElement('style');
-  style.textContent = fs.readFileSync(CSS_PATH, 'utf8').replace(/:not\(#\\9\)/g, '');
-  document.head.appendChild(style);
-
-  const rules: CSSStyleRule[] = [];
-  const collect = (list: CSSRuleList) => {
-    for (const rule of Array.from(list)) {
-      if (rule instanceof CSSMediaRule) {
-        collect(rule.cssRules);
-      } else if (rule instanceof CSSStyleRule) {
-        rules.push(rule);
-      }
-    }
-  };
-  collect(style.sheet!.cssRules);
-  document.head.removeChild(style);
-  return rules;
+function genericRuleSelector(): string {
+  const css = compile([THEME]);
+  const block = css.split('}').find(b => b.includes('scale(0.94)'));
+  if (!block) {
+    throw new Error('generic hover-motion rule not found in compiled CSS');
+  }
+  return block.slice(0, block.indexOf('{')).trim();
 }
-
-// Icon-specific motions
-const hoverRules = () => builtRules().filter(rule => /:hover|:focus-visible/.test(rule.selectorText));
-// Generic motion for icons that don't have their own motion
-const genericRule = () => hoverRules().find(rule => rule.style.transform === 'scale(0.94)')!;
 
 describe('the expressive-motion theme opt-in gate', () => {
   test('emits nothing for an artefact with no opted-in theme', () => {
@@ -96,33 +78,35 @@ describe('the expressive-motion theme opt-in gate', () => {
 
 describe('the generic hover motion rule, as compiled', () => {
   test('the generic rule carries the theme scope and both mode exclusions', () => {
-    expect(genericRule().selectorText).toContain(THEME);
-    expect(genericRule().selectorText).toContain(':not(.awsui-motion-disabled)');
-    expect(genericRule().selectorText).toContain(':not(.awsui-mode-entering)');
+    const selector = genericRuleSelector();
+    expect(selector).toContain(THEME);
+    expect(selector).toContain(':not(.awsui-motion-disabled)');
+    expect(selector).toContain(':not(.awsui-mode-entering)');
   });
 
   test('the generic rule targets the inner svg', () => {
-    expect(genericRule().style.transform).toBe('scale(0.94)');
-    const target = genericRule().selectorText.split(/\s+/).pop()!;
-    expect(target).toMatch(/^>?\s*svg\[data-awsui-icon-animated\]$/);
+    const target = genericRuleSelector().split(/\s+/).pop()!;
+    expect(target).toMatch(/^>?\s*:global\(svg\[data-awsui-icon-animated\]\)$/);
   });
 
   test('reduced motion is one wrapping media query, not a per-rule override', () => {
-    const css = fs.readFileSync(CSS_PATH, 'utf8');
+    const css = compile([THEME]);
     expect(css.match(/@media \(prefers-reduced-motion: no-preference\)/g)).toHaveLength(1);
     expect(css).not.toMatch(/prefers-reduced-motion:\s*reduce\b/);
   });
 
   test('the generic rule also fires on :focus-visible, guarded the same way as :hover', () => {
-    expect(genericRule().selectorText).toMatch(
+    expect(genericRuleSelector()).toMatch(
       /\[data-awsui-motion-trigger~=hover]:not\(:disabled\):not\(\[aria-disabled=true]\):is\(:focus-visible,/
     );
   });
 
   test('the disabled guard excludes aria-disabled="true" but not aria-disabled="false"', () => {
-    const selector = genericRule().selectorText;
+    const selector = genericRuleSelector();
     const hoverIndex = selector.indexOf(':hover');
-    const regionStart = selector.lastIndexOf(' ', hoverIndex) + 1;
+    // The region is the one compound immediately left of `:hover`. The theme scope sits
+    // further left, closed by `) ` (the end of the `:global(...)` wrapper), so start there.
+    const regionStart = selector.lastIndexOf(') ', hoverIndex) + 2;
     const region = selector.slice(regionStart, hoverIndex);
 
     const enabled = document.createElement('button');

--- a/src/icon/__tests__/icon-hover-motion.test.ts
+++ b/src/icon/__tests__/icon-hover-motion.test.ts
@@ -13,13 +13,6 @@ const CSS_PATH = path.join(BUILD_ROOT, 'icon/styles.scoped.css');
 
 const THEME = '.awsui-one-theme';
 
-// Only the two tokens the file actually reads. Real values are `var(--…)` references; literals
-// are used here so the compiled output stays inspectable.
-const TOKENS_STUB = `
-  $motion-duration-refresh-only-slow: 250ms;
-  $motion-easing-responsive: cubic-bezier(0, 0, 0.35, 1);
-`;
-
 /**
  * Compiles `hover-motion.scss` against the real `theming.scss`, for an artefact
  * whose `resolved-tokens` carry `optedInThemes`.
@@ -32,9 +25,6 @@ function compile(optedInThemes: string[]): string {
           if (url.endsWith('hover-motion')) {
             return new URL('mem:hover-motion');
           }
-          if (url.endsWith('tokens') && !url.startsWith('awsui:')) {
-            return new URL('mem:tokens');
-          }
           if (url.endsWith('theming')) {
             return new URL('mem:theming');
           }
@@ -46,7 +36,6 @@ function compile(optedInThemes: string[]): string {
         load(canonicalUrl: URL) {
           const contents = {
             'mem:hover-motion': HOVER_MOTION_SOURCE,
-            'mem:tokens': TOKENS_STUB,
             'mem:theming': THEMING_SOURCE,
             'mem:resolved-tokens': `$resolved-tokens: [${optedInThemes
               .map(selector => `(selector: "${selector}", tokens: ())`)

--- a/src/icon/__tests__/icon-hover-motion.test.ts
+++ b/src/icon/__tests__/icon-hover-motion.test.ts
@@ -49,7 +49,8 @@ function compile(optedInThemes: string[]): string {
 }
 
 /**
- * Every style rule in the REAL built stylesheet.
+ * Parses the built stylesheet into real CSSStyleRule objects, so tests can
+ * assert on selectorText and style instead of matching raw CSS text.
  */
 function builtRules(): CSSStyleRule[] {
   const style = document.createElement('style');
@@ -76,31 +77,32 @@ const hoverRules = () => builtRules().filter(rule => /:hover|:focus-visible/.tes
 // Generic motion for icons that don't have their own motion
 const genericRule = () => hoverRules().find(rule => rule.style.transform === 'scale(0.94)')!;
 
-describe('the theme gate', () => {
+describe('the expressive-motion theme opt-in gate', () => {
   test('emits nothing for an artefact with no opted-in theme', () => {
     const css = compile([]);
     expect(css).not.toContain('scale(0.94)');
     expect(css).not.toContain('data-awsui-motion-trigger');
   });
 
-  test('emits the floor, scoped to the theme, once the theme opts in', () => {
+  test('emits generic motion, scoped to the theme, once the theme opts in', () => {
     const css = compile([THEME]);
-    expect(css).toContain(THEME);
-    expect(css).toContain('scale(0.94)');
-    expect(css).toContain('data-awsui-motion-trigger');
+    const scaleBlock = css.split('}').find(block => block.includes('scale(0.94)'));
+
+    expect(scaleBlock).toBeDefined();
+    expect(scaleBlock).toContain(THEME);
+    expect(scaleBlock).toContain('data-awsui-motion-trigger');
   });
 });
 
-describe('the real built stylesheet', () => {
-  test('the floor rule carries the theme scope and both mode exclusions', () => {
+describe('the generic hover motion rule, as compiled', () => {
+  test('the generic rule carries the theme scope and both mode exclusions', () => {
     expect(genericRule().selectorText).toContain(THEME);
     expect(genericRule().selectorText).toContain(':not(.awsui-motion-disabled)');
     expect(genericRule().selectorText).toContain(':not(.awsui-mode-entering)');
   });
 
-  test('the floor targets the INNER svg, never the outer .icon span', () => {
+  test('the generic rule targets the inner svg', () => {
     expect(genericRule().style.transform).toBe('scale(0.94)');
-    // The rule's target is the last compound; it must be the opted-in svg, not a bare `.icon`.
     const target = genericRule().selectorText.split(/\s+/).pop()!;
     expect(target).toMatch(/^>?\s*svg\[data-awsui-icon-animated\]$/);
   });
@@ -111,16 +113,13 @@ describe('the real built stylesheet', () => {
     expect(css).not.toMatch(/prefers-reduced-motion:\s*reduce\b/);
   });
 
-  test('the floor also fires on :focus-visible, guarded the same way as :hover', () => {
+  test('the generic rule also fires on :focus-visible, guarded the same way as :hover', () => {
     expect(genericRule().selectorText).toMatch(
       /\[data-awsui-motion-trigger~=hover]:not\(:disabled\):not\(\[aria-disabled=true]\):is\(:focus-visible,/
     );
   });
 
-  test('the disabled guard matches by exact value — an ENABLED control still animates', () => {
-    // The region is the one compound immediately left of `:hover` — an ancestor theme scope
-    // sits further left, joined by a descendant combinator, so it must not be included: a
-    // bare region element has no such ancestor and would otherwise never match.
+  test('the disabled guard excludes aria-disabled="true" but not aria-disabled="false"', () => {
     const selector = genericRule().selectorText;
     const hoverIndex = selector.indexOf(':hover');
     const regionStart = selector.lastIndexOf(' ', hoverIndex) + 1;
@@ -141,7 +140,7 @@ describe('the real built stylesheet', () => {
     expect(ariaDisabled.matches(region)).toBe(false);
 
     // Positive control: React stringifies `aria-disabled={false}` to the string "false" on an
-    // ENABLED control. A bare `[aria-disabled]` guard would wrongly exclude this one too.
+    // ENABLED control. A bare `[aria-disabled]` guard must work.
     const ariaEnabled = document.createElement('button');
     ariaEnabled.setAttribute('data-awsui-motion-trigger', 'hover');
     ariaEnabled.setAttribute('aria-disabled', 'false');

--- a/src/icon/__tests__/icon-hover-motion.test.ts
+++ b/src/icon/__tests__/icon-hover-motion.test.ts
@@ -103,10 +103,12 @@ describe('the generic hover motion rule, as compiled', () => {
 
   test('the disabled guard excludes aria-disabled="true" but not aria-disabled="false"', () => {
     const selector = genericRuleSelector();
+    // Example selector: `:global(.awsui-one-theme...) [data-awsui-motion-trigger~=hover]:not(...):hover ...`
+    // The region under test is everything between the theme scope's `:global(...)` wrapper
+    // and `:hover`, here: `[data-awsui-motion-trigger~=hover]:not(:disabled):not([aria-disabled=true])`.
     const hoverIndex = selector.indexOf(':hover');
-    // The region is the one compound immediately left of `:hover`. The theme scope sits
-    // further left, closed by `) ` (the end of the `:global(...)` wrapper), so start there.
-    const regionStart = selector.lastIndexOf(') ', hoverIndex) + 2;
+    const globalIndex = selector.indexOf(':global(');
+    const regionStart = selector.indexOf(') ', globalIndex) + 2;
     const region = selector.slice(regionStart, hoverIndex);
 
     const enabled = document.createElement('button');

--- a/src/icon/__tests__/icon-hover-motion.test.ts
+++ b/src/icon/__tests__/icon-hover-motion.test.ts
@@ -1,0 +1,167 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as sass from 'sass';
+
+const HOVER_MOTION_SOURCE = fs.readFileSync(path.join(__dirname, '..', 'hover-motion.scss'), 'utf8');
+const THEMING_SOURCE = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'internal', 'styles', 'utils', 'theming.scss'),
+  'utf8'
+);
+const CSS_PATH = path.join(__dirname, '..', '..', '..', 'lib', 'components', 'icon', 'styles.scoped.css');
+
+const THEME = '.awsui-one-theme';
+
+// Only the two tokens the file actually reads. Real values are `var(--…)` references; literals
+// are used here so the compiled output stays inspectable.
+const TOKENS_STUB = `
+  $motion-duration-refresh-only-slow: 250ms;
+  $motion-easing-responsive: cubic-bezier(0, 0, 0.35, 1);
+`;
+
+/**
+ * Compiles `hover-motion.scss` against the real `theming.scss`, for an artefact whose
+ * `resolved-tokens` carry `optedInThemes`. dart-sass's filesystem importer crashes under
+ * jest's jsdom environment, so every module is served from memory.
+ */
+function compile(optedInThemes: string[]): string {
+  return sass.compileString(`@use 'hover-motion' as hover-motion;\n@include hover-motion.icon-hover-motion;`, {
+    importers: [
+      {
+        canonicalize(url: string) {
+          if (url.endsWith('hover-motion')) {
+            return new URL('mem:hover-motion');
+          }
+          if (url.endsWith('tokens') && !url.startsWith('awsui:')) {
+            return new URL('mem:tokens');
+          }
+          if (url.endsWith('theming')) {
+            return new URL('mem:theming');
+          }
+          if (url.startsWith('awsui:')) {
+            return new URL('mem:resolved-tokens');
+          }
+          return null;
+        },
+        load(canonicalUrl: URL) {
+          const contents = {
+            'mem:hover-motion': HOVER_MOTION_SOURCE,
+            'mem:tokens': TOKENS_STUB,
+            'mem:theming': THEMING_SOURCE,
+            'mem:resolved-tokens': `$resolved-tokens: [${optedInThemes
+              .map(selector => `(selector: "${selector}", tokens: ())`)
+              .join(',')}];`,
+          }[canonicalUrl.href];
+          return { contents: contents ?? '', syntax: 'scss' as const };
+        },
+      },
+    ],
+  }).css;
+}
+
+/**
+ * Every style rule in the REAL built stylesheet, read through the CSSOM rather than a
+ * bespoke selector parser — the browser's own parser already handles comma lists, `:is()`
+ * and `@media` nesting correctly. The postcss `:not(#\\9)` specificity hack is stripped first:
+ * it can never match an element, and jsdom's selector engine refuses to compile the escape.
+ */
+function builtRules(): CSSStyleRule[] {
+  const style = document.createElement('style');
+  style.textContent = fs.readFileSync(CSS_PATH, 'utf8').replace(/:not\(#\\9\)/g, '');
+  document.head.appendChild(style);
+
+  const rules: CSSStyleRule[] = [];
+  const collect = (list: CSSRuleList) => {
+    for (const rule of Array.from(list)) {
+      if (rule instanceof CSSMediaRule) {
+        collect(rule.cssRules);
+      } else if (rule instanceof CSSStyleRule) {
+        rules.push(rule);
+      }
+    }
+  };
+  collect(style.sheet!.cssRules);
+  document.head.removeChild(style);
+  return rules;
+}
+
+const hoverRules = () => builtRules().filter(rule => /:hover|:focus-visible/.test(rule.selectorText));
+const floorRule = () => hoverRules().find(rule => rule.style.transform === 'scale(0.94)')!;
+
+describe('the theme gate', () => {
+  test('emits nothing for an artefact with no opted-in theme', () => {
+    const css = compile([]);
+    expect(css).not.toContain('scale(0.94)');
+    expect(css).not.toContain('data-awsui-motion-trigger');
+  });
+
+  test('emits the floor, scoped to the theme, once the theme opts in', () => {
+    const css = compile([THEME]);
+    expect(css).toContain(THEME);
+    expect(css).toContain('scale(0.94)');
+    expect(css).toContain('data-awsui-motion-trigger');
+  });
+});
+
+describe('the real built stylesheet', () => {
+  test('the floor rule carries the theme scope and both mode exclusions', () => {
+    expect(floorRule().selectorText).toContain(THEME);
+    expect(floorRule().selectorText).toContain(':not(.awsui-motion-disabled)');
+    expect(floorRule().selectorText).toContain(':not(.awsui-mode-entering)');
+  });
+
+  test('the floor targets the INNER svg, never the outer .icon span', () => {
+    expect(floorRule().style.transform).toBe('scale(0.94)');
+    // The rule's target is the last compound; it must be the opted-in svg, not a bare `.icon`.
+    const target = floorRule().selectorText.split(/\s+/).pop()!;
+    expect(target).toMatch(/^>?\s*svg\[data-awsui-icon-animated\]$/);
+  });
+
+  test('reduced motion is one wrapping media query, not a per-rule override', () => {
+    const css = fs.readFileSync(CSS_PATH, 'utf8');
+    expect(css.match(/@media \(prefers-reduced-motion: no-preference\)/g)).toHaveLength(1);
+    expect(css).not.toMatch(/prefers-reduced-motion:\s*reduce\b/);
+  });
+
+  test('no `@keyframes` are emitted', () => {
+    expect(fs.readFileSync(CSS_PATH, 'utf8')).not.toMatch(/@keyframes/);
+  });
+
+  test('the floor also fires on :focus-visible, guarded the same way as :hover', () => {
+    expect(floorRule().selectorText).toMatch(
+      /\[data-awsui-motion-trigger~=hover]:not\(:disabled\):not\(\[aria-disabled=true]\):is\(:focus-visible,/
+    );
+  });
+
+  test('the disabled guard matches by exact value — an ENABLED control still animates', () => {
+    // The region is the one compound immediately left of `:hover` — an ancestor theme scope
+    // sits further left, joined by a descendant combinator, so it must not be included: a
+    // bare region element has no such ancestor and would otherwise never match.
+    const selector = floorRule().selectorText;
+    const hoverIndex = selector.indexOf(':hover');
+    const regionStart = selector.lastIndexOf(' ', hoverIndex) + 1;
+    const region = selector.slice(regionStart, hoverIndex);
+
+    const enabled = document.createElement('button');
+    enabled.setAttribute('data-awsui-motion-trigger', 'hover');
+    expect(enabled.matches(region)).toBe(true);
+
+    const nativeDisabled = document.createElement('button');
+    nativeDisabled.setAttribute('data-awsui-motion-trigger', 'hover');
+    nativeDisabled.disabled = true;
+    expect(nativeDisabled.matches(region)).toBe(false);
+
+    const ariaDisabled = document.createElement('button');
+    ariaDisabled.setAttribute('data-awsui-motion-trigger', 'hover');
+    ariaDisabled.setAttribute('aria-disabled', 'true');
+    expect(ariaDisabled.matches(region)).toBe(false);
+
+    // Positive control: React stringifies `aria-disabled={false}` to the string "false" on an
+    // ENABLED control. A bare `[aria-disabled]` guard would wrongly exclude this one too.
+    const ariaEnabled = document.createElement('button');
+    ariaEnabled.setAttribute('data-awsui-motion-trigger', 'hover');
+    ariaEnabled.setAttribute('aria-disabled', 'false');
+    expect(ariaEnabled.matches(region)).toBe(true);
+  });
+});

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -7,7 +7,6 @@
 // expressive motion via the `$expressive-motion-themes` list in
 // internal/styles/utils/theming.scss.
 
-@use '../internal/styles/tokens' as awsui;
 @use '../internal/styles/utils/theming' as theming;
 
 // Descendant combinators and type selectors are unavoidable here since the trigger
@@ -15,8 +14,9 @@
 // stylelint-disable selector-combinator-disallowed-list, selector-max-type, selector-class-pattern
 // stylelint-disable @cloudscape-design/no-implicit-descendant
 
-$_duration-generic: awsui.$motion-duration-refresh-only-slow;
-$_ease-decelerate: awsui.$motion-easing-responsive;
+// Local literals, not motion tokens, until expressive motion has tokens of its own.
+$_duration-generic: 250ms;
+$_ease-decelerate: cubic-bezier(0, 0, 0, 1);
 
 // A disabled control must not react to hover.
 $_enabled-only: ':not(:disabled):not([aria-disabled="true"])';

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -14,7 +14,6 @@
 // stylelint-disable selector-combinator-disallowed-list, selector-max-type, selector-class-pattern
 // stylelint-disable @cloudscape-design/no-implicit-descendant
 
-// Local literals, not motion tokens, until expressive motion has tokens of its own.
 $_duration-generic: 250ms;
 $_ease-decelerate: cubic-bezier(0, 0, 0, 1);
 
@@ -36,9 +35,8 @@ $_hover-trigger: '[#{$_trigger-attribute}~="hover"]#{$_enabled-only}';
 $_target-attribute: 'data-awsui-motion-target';
 $_animating-icon: ':is([#{$_target-attribute}], :where([#{$_target-attribute}] *))';
 
-// List for bespoke per-icon motion. An icon with no entry in
-// `$icon-hover-motion` gets the generic hover motion if the SVG is tagged with
-// `data-awsui-icon-animated`.
+// List for bespoke per-icon motion. An icon with no entry in `$icon-hover-motion`
+// gets the generic hover motion if the SVG is tagged with `data-awsui-icon-animated`.
 $icon-hover-motion: ();
 
 // Named with-motion so the no-motion-outside-of-mixin stylelint rule can find callers.
@@ -73,7 +71,6 @@ $icon-hover-motion: ();
 }
 
 @mixin icon-hover-motion {
-  // Wrapped once so prefers-reduced-motion can suppress all of this in one go.
   @media (prefers-reduced-motion: no-preference) {
     @include generic-hover-motion;
   }

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -1,0 +1,86 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+// Hover-only icon micro-interactions, emitted only for themes that opt in to expressive
+// motion. An icon with no bespoke entry in `$icon-hover-motion` gets the generic floor.
+//
+// Targets the inner svg, not the outer .icon span, which already carries RTL mirroring
+// and caret rotation.
+
+@use '../internal/styles/tokens' as awsui;
+@use '../internal/styles/utils/theming' as theming;
+
+// The trigger is an ancestor element and the target is an SVG shape, so descendant
+// combinators and type selectors are unavoidable here.
+// stylelint-disable selector-combinator-disallowed-list, selector-max-type, selector-class-pattern
+// stylelint-disable @cloudscape-design/no-implicit-descendant
+
+$_duration-generic: awsui.$motion-duration-refresh-only-slow;
+$_ease-decelerate: awsui.$motion-easing-responsive;
+
+// A disabled control must not react to hover.
+$_enabled-only: ':not(:disabled):not([aria-disabled="true"])';
+
+// Motion must only play if .awsui-motion-disabled and .awsui-mode-entering are not set
+$_motion-on: ':not(.awsui-motion-disabled):not(.awsui-mode-entering)';
+
+// Any value enables motion — the generator always sets this to "true".
+$_animated-attribute: 'data-awsui-icon-animated';
+$_opted-in: 'svg[#{$_animated-attribute}]';
+
+// An explicit opt-in attribute, not a tag/role list, so non-interactive containers can be triggers too.
+$_trigger-attribute: 'data-awsui-motion-trigger';
+$_hover-trigger: '[#{$_trigger-attribute}~="hover"]#{$_enabled-only}';
+
+// The svg has pointer-events: none, so hover is always taken by the trigger, never the icon itself.
+$_target-attribute: 'data-awsui-motion-target';
+$_animating-icon: ':is([#{$_target-attribute}], :where([#{$_target-attribute}] *))';
+
+// A uniform scale needs no re-cut and survives icon rotation or the RTL mirror.
+$_generic-transform: scale(0.94);
+
+// Extension point for bespoke per-icon motion.
+$icon-hover-motion: ();
+
+// Named with-motion so the no-motion-outside-of-mixin stylelint rule can find callers.
+@mixin with-motion {
+  @include theming.expressive-motion-only($_motion-on) {
+    @content;
+  }
+}
+
+// Also fires on :focus-visible, covering a focus owner nested inside the trigger.
+@mixin _on-hover-trigger($suffix) {
+  #{'#{$_hover-trigger}:hover #{$suffix}'},
+  #{'#{$_hover-trigger}:is(:focus-visible, :has([#{$_trigger-attribute}~="focus"]:focus-visible)) #{$suffix}'} {
+    @content;
+  }
+}
+
+@mixin generic-hover-motion {
+  .icon > :global(#{$_opted-in}) {
+    @include with-motion {
+      transition-property: transform;
+      transition-duration: $_duration-generic;
+      transition-timing-function: $_ease-decelerate;
+    }
+  }
+
+  @include _on-hover-trigger('.icon#{$_animating-icon} > :global(#{$_opted-in})') {
+    @include with-motion {
+      transform: $_generic-transform;
+    }
+  }
+}
+
+@mixin icon-hover-motion {
+  // Wrapped once so prefers-reduced-motion can suppress all of this without a per-rule override.
+  @media (prefers-reduced-motion: no-preference) {
+    @include generic-hover-motion;
+  }
+}
+
+// stylelint-enable selector-combinator-disallowed-list, selector-max-type, selector-class-pattern
+// stylelint-enable @cloudscape-design/no-implicit-descendant

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -3,17 +3,15 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-// Hover-only icon micro-interactions, emitted only for themes that opt in to expressive
-// motion. An icon with no bespoke entry in `$icon-hover-motion` gets the generic floor.
-//
-// Targets the inner svg, not the outer .icon span, which already carries RTL mirroring
-// and caret rotation.
+// This file holds icon hover motions, emitted only for themes that opt in to
+// expressive motion via the `$expressive-motion-themes` list in
+// internal/styles/utils/theming.scss.
 
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/styles/utils/theming' as theming;
 
-// The trigger is an ancestor element and the target is an SVG shape, so descendant
-// combinators and type selectors are unavoidable here.
+// Descendant combinators and type selectors are unavoidable here since the trigger
+// is an ancestor element and the target is an SVG shape.
 // stylelint-disable selector-combinator-disallowed-list, selector-max-type, selector-class-pattern
 // stylelint-disable @cloudscape-design/no-implicit-descendant
 
@@ -23,25 +21,24 @@ $_ease-decelerate: awsui.$motion-easing-responsive;
 // A disabled control must not react to hover.
 $_enabled-only: ':not(:disabled):not([aria-disabled="true"])';
 
-// Motion must only play if .awsui-motion-disabled and .awsui-mode-entering are not set
+// Motion must only play if .awsui-motion-disabled and .awsui-mode-entering are not set.
 $_motion-on: ':not(.awsui-motion-disabled):not(.awsui-mode-entering)';
 
-// Any value enables motion — the generator always sets this to "true".
+// The following data attribute on an SVG enables motion.
 $_animated-attribute: 'data-awsui-icon-animated';
 $_opted-in: 'svg[#{$_animated-attribute}]';
 
-// An explicit opt-in attribute, not a tag/role list, so non-interactive containers can be triggers too.
+// Opt-in attribute for which element triggers hover motion.
 $_trigger-attribute: 'data-awsui-motion-trigger';
 $_hover-trigger: '[#{$_trigger-attribute}~="hover"]#{$_enabled-only}';
 
-// The svg has pointer-events: none, so hover is always taken by the trigger, never the icon itself.
+// Opt-in attribute for where the motion should be applied within a trigger region.
 $_target-attribute: 'data-awsui-motion-target';
 $_animating-icon: ':is([#{$_target-attribute}], :where([#{$_target-attribute}] *))';
 
-// A uniform scale needs no re-cut and survives icon rotation or the RTL mirror.
-$_generic-transform: scale(0.94);
-
-// Extension point for bespoke per-icon motion.
+// List for bespoke per-icon motion. An icon with no entry in
+// `$icon-hover-motion` gets the generic hover motion if the SVG is tagged with
+// `data-awsui-icon-animated`.
 $icon-hover-motion: ();
 
 // Named with-motion so the no-motion-outside-of-mixin stylelint rule can find callers.
@@ -70,13 +67,13 @@ $icon-hover-motion: ();
 
   @include _on-hover-trigger('.icon#{$_animating-icon} > :global(#{$_opted-in})') {
     @include with-motion {
-      transform: $_generic-transform;
+      transform: scale(0.94);
     }
   }
 }
 
 @mixin icon-hover-motion {
-  // Wrapped once so prefers-reduced-motion can suppress all of this without a per-rule override.
+  // Wrapped once so prefers-reduced-motion can suppress all of this in one go.
   @media (prefers-reduced-motion: no-preference) {
     @include generic-hover-motion;
   }

--- a/src/icon/styles.scss
+++ b/src/icon/styles.scss
@@ -6,6 +6,7 @@
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/styles' as styles;
 @use './mixins' as mixins;
+@use './hover-motion' as hover-motion;
 
 .icon {
   position: relative;
@@ -53,6 +54,8 @@
     }
   }
 }
+
+@include hover-motion.icon-hover-motion;
 
 .badge::after {
   content: '';


### PR DESCRIPTION
### Description

Adds generic icon motion logic which **does not yet take effect** as no regions have been tagged with the necessary data attributes (will be the last PR for this feature). This PR also introduces a stub for icon-specific motion which will be filled in a follow-up PR.

Tests verify rules are emitted only for opted-in themes and don't apply motion to disabled elements or if reduced-motion is enabled.

Context: `b9VcPdMJ5zRn`.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
