### PR TITLE
fix: Contain inline overflow in expandable section boxes in one theme

### DIFF
--- a/pages/expandable-section/permutations.page.tsx
+++ b/pages/expandable-section/permutations.page.tsx
@@ -15,6 +15,16 @@ import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
 
+// Eight 200px columns give the table a min-content width far wider than the section that holds it.
+const wideColumnDefinitions = Array.from({ length: 8 }, (_, index) => ({
+  id: `column-${index + 1}`,
+  header: `Configuration column ${index + 1}`,
+  cell: (item: { id: number }) => `Item ${item.id} value ${index + 1}`,
+  minWidth: 200,
+}));
+
+const wideItems = Array.from({ length: 3 }, (_, index) => ({ id: index + 1 }));
+
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<ExpandableSectionProps>([
   {
@@ -180,6 +190,14 @@ const endIconPermutations = createPermutations<ExpandableSectionProps>([
   },
 ]);
 
+const overflowPermutations = createPermutations<ExpandableSectionProps>([
+  {
+    defaultExpanded: [true],
+    variant: ['default', 'container'],
+    headerText: ['Content wider than the section'],
+  },
+]);
+
 export default function ExpandableSectionPermutations() {
   return (
     <>
@@ -192,6 +210,24 @@ export default function ExpandableSectionPermutations() {
             <InternalExpandableSection {...permutation} defaultExpanded={true} __expandIconPosition="end">
               Variant {permutation.variant} section content
             </InternalExpandableSection>
+          )}
+        />
+        {/* The narrow wrapper is outside the section on purpose: content that manages its own inline
+            overflow must scroll within the section rather than stretch it past the red boundary. */}
+        <PermutationsView
+          permutations={overflowPermutations}
+          render={permutation => (
+            <div style={{ inlineSize: 400, borderInline: '1px solid red', borderBlock: '1px solid red' }}>
+              <ExpandableSection {...permutation}>
+                <Table
+                  variant="embedded"
+                  columnDefinitions={wideColumnDefinitions}
+                  items={wideItems}
+                  // The scrollable table wrapper becomes a region landmark, which needs a unique name per permutation.
+                  ariaLabels={{ tableLabel: `Wide table in ${permutation.variant} section` }}
+                />
+              </ExpandableSection>
+            </div>
           )}
         />
       </ScreenshotArea>

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -352,12 +352,14 @@ $nav-caret-pad-one-theme: 12px; // 24px minus the one-theme x-small (12px) icon
 .content-inner {
   /* this comment keeps the class in the style sheet */
   @include theming.one-theme-only {
-    // overflow: visible lets negative-margin backgrounds (e.g. side-navigation
-    // active/hover/focus states) bleed past the inline edges.
-    overflow-x: visible;
-    // overflow: clip (not hidden, which would coerce x-axis to auto) still lets the grid-row track collapse.
+    // Grid item of .content above. `clip` rather than `hidden`: `hidden` coerces the inline axis
+    // to `auto`, making this a scroll container on both axes, where `clip` leaves the inline axis
+    // `visible` so content that paints outside the box (focus rings, inline popovers) survives.
     overflow-y: clip;
     min-block-size: 0;
+    // A grid item's automatic minimum size is content-based on this axis too, so content that
+    // manages its own inline overflow (e.g. a table) would stretch the box out of the container.
+    min-inline-size: 0;
     opacity: 0;
 
     // HIDE (collapsed state): quick opacity collapse, no delay.
@@ -541,12 +543,14 @@ $nav-caret-pad-one-theme: 12px; // 24px minus the one-theme x-small (12px) icon
   }
 }
 
-// min-block-size: 0 lets this grid item collapse to zero height when an ancestor
-// uses grid-template-rows: 0fr (side-navigation section header collapse).
-// Must remain global (not scoped to .header-icon-end) because the side-nav
-// collapse targets the header wrapper regardless of icon position.
+// Side-navigation makes this box a grid item (its section wrapper sets display: grid with
+// grid-template-rows: 0fr to collapse), and a grid item's automatic minimum size is content-based on
+// both axes: zero the block axis so the header collapses to zero, zero the inline axis so wide content
+// cannot stretch it past the track. It belongs here rather than on side-navigation's grid container,
+// because a container's min-size does not participate in track sizing.
 .header-content {
   min-block-size: 0;
+  min-inline-size: 0;
 }
 
 // In the end-icon layout, header content elements must shrink without overflowing.


### PR DESCRIPTION
### Description

In one theme, expandable section content is revealed by animating `grid-template-rows` from `0fr` to `1fr`, which makes `.content-inner` a grid item. A grid item's automatic minimum size is content-based on both axes, but only `min-block-size` was zeroed. Content that manages its own inline overflow (e.g. a table's horizontal scroll area) therefore resolved `min-inline-size: auto` to its min-content width and stretched the wrapper past its grid track and outside the section's container, producing a page-level horizontal scrollbar.

This adds `min-inline-size: 0` alongside the existing `min-block-size: 0`, leaving the `overflow-x: visible` / `overflow-y: clip` pairing untouched so the block axis can still collapse while negative-margin backgrounds (side navigation hover/active/focus states) keep bleeding past the inline edges.

The same pairing is applied to .header-content, which side navigation also makes a grid item via `.section >  :first-child { display: grid }`. `.header-actions-wrapper` and `.header-icon-end > .header-content` already zero the inline axis; this leaves the start-icon layout consistent with them rather than being the one header box that can outgrow its container.

Related links, issue #, if available: AWSUI-62232

### How has this been tested?
Manually, in a local one-theme dev build.

Can verify with `INCLUDE_ONE_THEME=true npm start`, then open an expandable section containing a wide table in one theme and confirm no horizontal page scrollbar appears during or after expansion, and the table inside expandable section does not overflow container.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
