### PR TITLE
feat: wire per-icon hover motion map into the emitters

### DIFF
--- a/pages/icon/motion.page.tsx
+++ b/pages/icon/motion.page.tsx
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Box from '~components/box';
+import Header from '~components/header';
+import Icon, { IconProps } from '~components/icon';
+import icons from '~components/icon/generated/icons';
+
+import styles from './icons-list.scss';
+
+const sizes = ['x-small', 'small', 'normal', 'medium', 'big', 'large'] as const;
+
+const triggerAttrs = { 'data-awsui-motion-trigger': 'hover', 'data-awsui-motion-target': 'true' } as const;
+
+export default function IconMotionPage() {
+  return (
+    <Box padding="l">
+      <Header variant="h1">Icon hover motion</Header>
+      {sizes.map(size => (
+        <div key={size} className={styles.wrapper}>
+          {Object.keys(icons).map(icon => (
+            <span key={icon} title={icon} {...triggerAttrs}>
+              <Icon name={icon as IconProps['name']} size={size} />
+            </span>
+          ))}
+        </div>
+      ))}
+    </Box>
+  );
+}

--- a/src/icon/__tests__/icon-hover-motion.test.ts
+++ b/src/icon/__tests__/icon-hover-motion.test.ts
@@ -145,6 +145,13 @@ describe('a malformed spec fails the build', () => {
     expect(both).not.toBe(HOVER_MOTION_SOURCE);
     expect(() => compile([THEME], both)).toThrow(/sets both `animation` and `to`/);
   });
+
+  test('a motion spec missing `duration` is rejected, naming the icon', () => {
+    // `announcement` is the first entry in the map, so the first match is its duration.
+    const missing = HOVER_MOTION_SOURCE.replace('      duration: 400ms,\n', '');
+    expect(missing).not.toBe(HOVER_MOTION_SOURCE);
+    expect(() => compile([THEME], missing)).toThrow(/spec for `announcement` sets motion but is missing/);
+  });
 });
 
 describe('keyframes', () => {

--- a/src/icon/__tests__/icon-hover-motion.test.ts
+++ b/src/icon/__tests__/icon-hover-motion.test.ts
@@ -12,10 +12,12 @@ const THEMING_SOURCE = fs.readFileSync(path.join(SRC_ROOT, 'internal/styles/util
 const THEME = '.awsui-one-theme';
 
 /**
- * Compiles `hover-motion.scss` against the real `theming.scss`, for an artefact
- * whose `resolved-tokens` carry `optedInThemes`.
+ * Compiles `hover-motion.scss` against the real `theming.scss`, for an artefact whose
+ * `resolved-tokens` carry `optedInThemes`. dart-sass's filesystem importer crashes under
+ * jest's jsdom environment, so every module is served from memory; `source` lets the
+ * mutation tests below patch the map without touching the file on disk.
  */
-function compile(optedInThemes: string[]): string {
+function compile(optedInThemes: string[], source: string = HOVER_MOTION_SOURCE): string {
   return sass.compileString(`@use 'hover-motion' as hover-motion;\n@include hover-motion.icon-hover-motion;`, {
     importers: [
       {
@@ -33,7 +35,7 @@ function compile(optedInThemes: string[]): string {
         },
         load(canonicalUrl: URL) {
           const contents = {
-            'mem:hover-motion': HOVER_MOTION_SOURCE,
+            'mem:hover-motion': source,
             'mem:theming': THEMING_SOURCE,
             'mem:resolved-tokens': `$resolved-tokens: [${optedInThemes
               .map(selector => `(selector: "${selector}", tokens: ())`)
@@ -102,34 +104,70 @@ describe('the generic hover motion rule, as compiled', () => {
   });
 
   test('the disabled guard excludes aria-disabled="true" but not aria-disabled="false"', () => {
-    const selector = genericRuleSelector();
-    // Example selector: `:global(.awsui-one-theme...) [data-awsui-motion-trigger~=hover]:not(...):hover ...`
-    // The region under test is everything between the theme scope's `:global(...)` wrapper
-    // and `:hover`, here: `[data-awsui-motion-trigger~=hover]:not(:disabled):not([aria-disabled=true])`.
-    const hoverIndex = selector.indexOf(':hover');
-    const globalIndex = selector.indexOf(':global(');
-    const regionStart = selector.indexOf(') ', globalIndex) + 2;
-    const region = selector.slice(regionStart, hoverIndex);
+    // The trigger's compound is whitespace-free (e.g. `[data-awsui-motion-trigger~=hover]:not(...):hover`),
+    // so token splitting isolates it; `:hover` is dropped since jsdom cannot set hover state.
+    const guard = genericRuleSelector()
+      .split(/\s+/)
+      .find(token => token.startsWith('[data-awsui-motion-trigger'))!
+      .replace(':hover', '');
 
-    const enabled = document.createElement('button');
-    enabled.setAttribute('data-awsui-motion-trigger', 'hover');
-    expect(enabled.matches(region)).toBe(true);
+    const button = (attributes: Record<string, string> = {}) => {
+      const element = document.createElement('button');
+      element.setAttribute('data-awsui-motion-trigger', 'hover');
+      for (const [name, value] of Object.entries(attributes)) {
+        element.setAttribute(name, value);
+      }
+      return element;
+    };
 
-    const nativeDisabled = document.createElement('button');
-    nativeDisabled.setAttribute('data-awsui-motion-trigger', 'hover');
-    nativeDisabled.disabled = true;
-    expect(nativeDisabled.matches(region)).toBe(false);
-
-    const ariaDisabled = document.createElement('button');
-    ariaDisabled.setAttribute('data-awsui-motion-trigger', 'hover');
-    ariaDisabled.setAttribute('aria-disabled', 'true');
-    expect(ariaDisabled.matches(region)).toBe(false);
+    expect(button().matches(guard)).toBe(true);
+    expect(button({ disabled: '' }).matches(guard)).toBe(false);
+    expect(button({ 'aria-disabled': 'true' }).matches(guard)).toBe(false);
 
     // Positive control: React stringifies `aria-disabled={false}` to the string "false" on an
-    // ENABLED control. A bare `[aria-disabled]` guard must work.
-    const ariaEnabled = document.createElement('button');
-    ariaEnabled.setAttribute('data-awsui-motion-trigger', 'hover');
-    ariaEnabled.setAttribute('aria-disabled', 'false');
-    expect(ariaEnabled.matches(region)).toBe(true);
+    // ENABLED control. A bare `[aria-disabled]` guard must not exclude it.
+    expect(button({ 'aria-disabled': 'false' }).matches(guard)).toBe(true);
+  });
+});
+
+describe('a malformed spec fails the build', () => {
+  test('an unknown key is rejected, naming the icon and the key', () => {
+    const typo = HOVER_MOTION_SOURCE.replace("part: 'awsui-icon-arm',", "pat: 'awsui-icon-arm',");
+    expect(typo).not.toBe(HOVER_MOTION_SOURCE);
+    expect(() => compile([THEME], typo)).toThrow(/Unknown key `pat` in the \$icon-hover-motion spec for `zoom-in`/);
+  });
+
+  test('a spec carrying both `animation` and `to` is rejected', () => {
+    const both = HOVER_MOTION_SOURCE.replace(
+      'animation: icon-pulse-soft,',
+      'animation: icon-pulse-soft,\n      to: (transform: scale(0.9)),'
+    );
+    expect(both).not.toBe(HOVER_MOTION_SOURCE);
+    expect(() => compile([THEME], both)).toThrow(/sets both `animation` and `to`/);
+  });
+});
+
+describe('keyframes', () => {
+  test('gated on the artefact: none for a theme that never opted in', () => {
+    expect(compile([])).not.toMatch(/@keyframes/);
+  });
+
+  test('every referenced animation name has a matching keyframes block', () => {
+    const css = compile([THEME]);
+    const referenced = new Set(Array.from(css.matchAll(/animation-name:\s*([\w-]+)/g)).map(match => match[1]));
+    expect(referenced.size).toBeGreaterThan(0);
+    for (const name of referenced) {
+      expect(css).toMatch(new RegExp(`@keyframes\\s+${name}\\s*\\{`));
+    }
+  });
+
+  test('no keyframes block is emitted that nothing in the map references', () => {
+    const css = compile([THEME]);
+    const defined = Array.from(css.matchAll(/@keyframes\s+([\w-]+)\s*\{/g)).map(match => match[1]);
+    const referenced = new Set(Array.from(css.matchAll(/animation-name:\s*([\w-]+)/g)).map(match => match[1]));
+    expect(defined.length).toBeGreaterThan(0);
+    for (const name of defined) {
+      expect(referenced.has(name)).toBe(true);
+    }
   });
 });

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -724,8 +724,9 @@ $icon-hover-motion: (
   ),
 );
 
-// Conditional motion declarations go through this mixin: the no-motion-outside-of-mixin
-// stylelint rule only accepts declarations directly under `with-motion`.
+// The no-motion-outside-of-mixin stylelint rule checks literally written animation/transition
+// declarations, requiring `@include with-motion` as their direct parent. Dynamic declarations
+// emitted here are invisible to it — only call this inside `with-motion`.
 @mixin _declarations($declarations) {
   @each $property, $value in $declarations {
     #{$property}: #{$value};

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -7,6 +7,9 @@
 // expressive motion via the `$expressive-motion-themes` list in
 // internal/styles/utils/theming.scss.
 
+@use 'sass:list';
+@use 'sass:map';
+@use 'sass:meta';
 @use '../internal/styles/utils/theming' as theming;
 
 // Descendant combinators and type selectors are unavoidable here since the trigger
@@ -14,8 +17,10 @@
 // stylelint-disable selector-combinator-disallowed-list, selector-max-type, selector-class-pattern
 // stylelint-disable @cloudscape-design/no-implicit-descendant
 
-$_duration-generic: 250ms;
-$_ease-decelerate: cubic-bezier(0, 0, 0, 1);
+$_ease-out: ease-out;
+$_ease-symmetric: cubic-bezier(0.33, 0, 0.67, 1);
+$_ease-decelerate: cubic-bezier(0.4, 0, 0.2, 1);
+$_ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
 
 // A disabled control must not react to hover.
 $_enabled-only: ':not(:disabled):not([aria-disabled="true"])';
@@ -34,10 +39,6 @@ $_hover-trigger: '[#{$_trigger-attribute}~="hover"]#{$_enabled-only}';
 // Opt-in attribute for where the motion should be applied within a trigger region.
 $_target-attribute: 'data-awsui-motion-target';
 $_animating-icon: ':is([#{$_target-attribute}], :where([#{$_target-attribute}] *))';
-
-$_ease-out: ease-out;
-$_ease-symmetric: cubic-bezier(0.33, 0, 0.67, 1);
-$_ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
 
 $icon-hover-motion: (
   'announcement': (
@@ -723,6 +724,201 @@ $icon-hover-motion: (
   ),
 );
 
+@mixin _declarations($declarations) {
+  @each $property, $value in $declarations {
+    #{$property}: #{$value};
+  }
+}
+
+// Named with-motion so the no-motion-outside-of-mixin stylelint rule can find callers.
+@mixin with-motion {
+  @include theming.expressive-motion-only($_motion-on) {
+    @content;
+  }
+}
+
+// Also fires on :focus-visible, covering a focus owner nested inside the trigger.
+@mixin _on-hover-trigger($suffix) {
+  #{'#{$_hover-trigger}:hover #{$suffix}'},
+  #{'#{$_hover-trigger}:is(:focus-visible, :has([#{$_trigger-attribute}~="focus"]:focus-visible)) #{$suffix}'} {
+    @content;
+  }
+}
+
+@function _target($part) {
+  @if not $part {
+    @return '> :global(#{$_opted-in})';
+  }
+  @return '> :global(#{$_opted-in} .#{$part})';
+}
+
+// A single-spec entry needs a trailing comma or Prettier turns the list back into a bare map.
+@function _specs($value) {
+  @if meta.type-of($value) == 'map' {
+    @return list.append((), $value);
+  }
+  @return $value;
+}
+
+@mixin generic-hover-motion {
+  .icon > :global(#{$_opted-in}) {
+    @include with-motion {
+      transition-property: transform;
+      transition-duration: 250ms;
+      transition-timing-function: $_ease-decelerate;
+    }
+  }
+
+  @include _on-hover-trigger('.icon#{$_animating-icon} > :global(#{$_opted-in})') {
+    @include with-motion {
+      transform: scale(0.94);
+    }
+  }
+}
+
+// Icons with BOTH a whole-icon spec and a part spec are excluded — the cancel would out-specify the whole-icon rule and reset it to none.
+@mixin _cancel-floor-under-hover-parts {
+  $names: ();
+  $parts: ();
+
+  @each $name, $specs in $icon-hover-motion {
+    $whole-icon: false;
+    @each $spec in _specs($specs) {
+      @if not map.get($spec, part) {
+        $whole-icon: true;
+      }
+    }
+
+    @if not $whole-icon {
+      @each $spec in _specs($specs) {
+        $part: map.get($spec, part);
+        @if $part {
+          @if not list.index($names, '.name-#{$name}') {
+            $names: list.append($names, '.name-#{$name}', comma);
+          }
+          @if not list.index($parts, '.#{$part}') {
+            $parts: list.append($parts, '.#{$part}', comma);
+          }
+        }
+      }
+    }
+  }
+
+  @if list.length($names) > 0 {
+    @include _on-hover-trigger('.icon#{$_animating-icon}:is(#{$names}) > :global(#{$_opted-in}:has(:is(#{$parts})))') {
+      @include with-motion {
+        transform: none;
+      }
+    }
+  }
+}
+
+@mixin per-icon-hover-motion {
+  @each $name, $specs in $icon-hover-motion {
+    @each $spec in _specs($specs) {
+      $part: map.get($spec, part);
+      $target: _target($part);
+      $to: map.get($spec, to);
+      $animation: map.get($spec, animation);
+      $duration: map.get($spec, duration);
+      $easing: map.get($spec, easing);
+      $base: map.get($spec, base);
+      $origin: map.get($spec, origin);
+
+      $property: map.get($spec, property);
+      @if not $property {
+        $property: transform;
+      }
+      $iterations: map.get($spec, iterations);
+      @if not $iterations {
+        $iterations: 1;
+      }
+      $fill: map.get($spec, fill);
+      @if not $fill {
+        $fill: none;
+      }
+      $delay: map.get($spec, delay);
+      @if not $delay {
+        $delay: 0s;
+      }
+
+      // base/origin are visually inert at rest, so riding inside the motion gate costs nothing.
+      @if $to or $base or $origin {
+        $resting: ();
+        @if $to {
+          $resting: map.merge(
+            $resting,
+            (
+              transition-property: #{$property},
+              transition-duration: $duration,
+              transition-timing-function: $easing,
+            )
+          );
+        }
+        @if $base {
+          $resting: map.merge($resting, $base);
+        }
+        @if $origin {
+          $resting: map.merge(
+            $resting,
+            (
+              transform-origin: $origin,
+            )
+          );
+        }
+
+        .icon.name-#{$name} #{$target} {
+          @include with-motion {
+            @include _declarations($resting);
+          }
+        }
+      }
+
+      @include _on-hover-trigger('.icon#{$_animating-icon}.name-#{$name} #{$target}') {
+        @if $animation {
+          $optional: ();
+          @if $iterations != 1 {
+            $optional: map.merge(
+              $optional,
+              (
+                animation-iteration-count: $iterations,
+              )
+            );
+          }
+          @if $fill != none {
+            $optional: map.merge(
+              $optional,
+              (
+                animation-fill-mode: $fill,
+              )
+            );
+          }
+          @if $delay != 0s {
+            $optional: map.merge(
+              $optional,
+              (
+                animation-delay: $delay,
+              )
+            );
+          }
+
+          @include with-motion {
+            animation-name: $animation;
+            animation-duration: $duration;
+            animation-timing-function: $easing;
+            @include _declarations($optional);
+          }
+        }
+        @if $to {
+          @include with-motion {
+            @include _declarations($to);
+          }
+        }
+      }
+    }
+  }
+}
+
 // @keyframes cannot nest under a class, so they're gated on the artefact instead of the selector.
 @mixin keyframes {
   @if theming.has-expressive-motion() {
@@ -1005,40 +1201,35 @@ $icon-hover-motion: (
   }
 }
 
-// Named with-motion so the no-motion-outside-of-mixin stylelint rule can find callers.
-@mixin with-motion {
-  @include theming.expressive-motion-only($_motion-on) {
-    @content;
-  }
-}
+$_spec-keys: (part, animation, to, base, origin, duration, easing, delay, iterations, fill, property);
 
-// Also fires on :focus-visible, covering a focus owner nested inside the trigger.
-@mixin _on-hover-trigger($suffix) {
-  #{'#{$_hover-trigger}:hover #{$suffix}'},
-  #{'#{$_hover-trigger}:is(:focus-visible, :has([#{$_trigger-attribute}~="focus"]:focus-visible)) #{$suffix}'} {
-    @content;
-  }
-}
+@mixin _validate-specs {
+  @each $name, $specs in $icon-hover-motion {
+    @each $spec in _specs($specs) {
+      @each $key, $value in $spec {
+        @if not list.index($_spec-keys, $key) {
+          @error 'Unknown key `#{$key}` in the $icon-hover-motion spec for `#{$name}`. ' +
+            'Known keys: #{$_spec-keys}.';
+        }
+      }
 
-@mixin generic-hover-motion {
-  .icon > :global(#{$_opted-in}) {
-    @include with-motion {
-      transition-property: transform;
-      transition-duration: $_duration-generic;
-      transition-timing-function: $_ease-decelerate;
-    }
-  }
-
-  @include _on-hover-trigger('.icon#{$_animating-icon} > :global(#{$_opted-in})') {
-    @include with-motion {
-      transform: scale(0.94);
+      @if map.get($spec, animation) and map.get($spec, to) {
+        @error 'The $icon-hover-motion spec for `#{$name}` sets both `animation` and `to`. ' +
+          'Use `animation` for keyframe-driven motion or `to` for a transition, not both.';
+      }
     }
   }
 }
 
 @mixin icon-hover-motion {
+  @include _validate-specs;
+
+  @include keyframes;
+
   @media (prefers-reduced-motion: no-preference) {
     @include generic-hover-motion;
+    @include _cancel-floor-under-hover-parts;
+    @include per-icon-hover-motion;
   }
 }
 

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -724,6 +724,9 @@ $icon-hover-motion: (
   ),
 );
 
+// Conditional motion declarations must go through this mixin: the no-motion-outside-of-mixin
+// stylelint rule only accepts declarations sitting directly under `with-motion`, so an
+// intervening `@if` would trip it even though the output stays inside the gate.
 @mixin _declarations($declarations) {
   @each $property, $value in $declarations {
     #{$property}: #{$value};
@@ -789,16 +792,13 @@ $icon-hover-motion: (
       }
     }
 
+    // Without a whole-icon spec, every spec has a `part`.
     @if not $whole-icon {
+      $names: list.append($names, '.name-#{$name}', comma);
       @each $spec in _specs($specs) {
-        $part: map.get($spec, part);
-        @if $part {
-          @if not list.index($names, '.name-#{$name}') {
-            $names: list.append($names, '.name-#{$name}', comma);
-          }
-          @if not list.index($parts, '.#{$part}') {
-            $parts: list.append($parts, '.#{$part}', comma);
-          }
+        $part: '.#{map.get($spec, part)}';
+        @if not list.index($parts, $part) {
+          $parts: list.append($parts, $part, comma);
         }
       }
     }
@@ -825,88 +825,61 @@ $icon-hover-motion: (
       $base: map.get($spec, base);
       $origin: map.get($spec, origin);
 
-      $property: map.get($spec, property);
-      @if not $property {
-        $property: transform;
-      }
-      $iterations: map.get($spec, iterations);
-      @if not $iterations {
-        $iterations: 1;
-      }
-      $fill: map.get($spec, fill);
-      @if not $fill {
-        $fill: none;
-      }
-      $delay: map.get($spec, delay);
-      @if not $delay {
-        $delay: 0s;
-      }
+      $property: map.get($spec, property) or transform;
+      $iterations: map.get($spec, iterations) or 1;
+      $fill: map.get($spec, fill) or none;
+      $delay: map.get($spec, delay) or 0s;
 
       // base/origin are visually inert at rest, so riding inside the motion gate costs nothing.
       @if $to or $base or $origin {
-        $resting: ();
-        @if $to {
-          $resting: map.merge(
-            $resting,
-            (
-              transition-property: #{$property},
-              transition-duration: $duration,
-              transition-timing-function: $easing,
-            )
-          );
-        }
-        @if $base {
-          $resting: map.merge($resting, $base);
-        }
-        @if $origin {
-          $resting: map.merge(
-            $resting,
-            (
-              transform-origin: $origin,
-            )
-          );
-        }
-
         .icon.name-#{$name} #{$target} {
           @include with-motion {
-            @include _declarations($resting);
+            @if $to {
+              @include _declarations(
+                (
+                  transition-property: #{$property},
+                  transition-duration: $duration,
+                  transition-timing-function: $easing,
+                )
+              );
+            }
+            @if $base {
+              @include _declarations($base);
+            }
+            @if $origin {
+              transform-origin: $origin;
+            }
           }
         }
       }
 
       @include _on-hover-trigger('.icon#{$_animating-icon}.name-#{$name} #{$target}') {
         @if $animation {
-          $optional: ();
-          @if $iterations != 1 {
-            $optional: map.merge(
-              $optional,
-              (
-                animation-iteration-count: $iterations,
-              )
-            );
-          }
-          @if $fill != none {
-            $optional: map.merge(
-              $optional,
-              (
-                animation-fill-mode: $fill,
-              )
-            );
-          }
-          @if $delay != 0s {
-            $optional: map.merge(
-              $optional,
-              (
-                animation-delay: $delay,
-              )
-            );
-          }
-
           @include with-motion {
             animation-name: $animation;
             animation-duration: $duration;
             animation-timing-function: $easing;
-            @include _declarations($optional);
+            @if $iterations != 1 {
+              @include _declarations(
+                (
+                  animation-iteration-count: $iterations,
+                )
+              );
+            }
+            @if $fill != none {
+              @include _declarations(
+                (
+                  animation-fill-mode: $fill,
+                )
+              );
+            }
+            @if $delay != 0s {
+              @include _declarations(
+                (
+                  animation-delay: $delay,
+                )
+              );
+            }
           }
         }
         @if $to {
@@ -1216,6 +1189,14 @@ $_spec-keys: (part, animation, to, base, origin, duration, easing, delay, iterat
       @if map.get($spec, animation) and map.get($spec, to) {
         @error 'The $icon-hover-motion spec for `#{$name}` sets both `animation` and `to`. ' +
           'Use `animation` for keyframe-driven motion or `to` for a transition, not both.';
+      }
+
+      @if (map.get($spec, animation) or map.get($spec, to)) and not
+        (map.get($spec, duration) and map.get($spec, easing))
+      {
+        @error 'The $icon-hover-motion spec for `#{$name}` sets motion but is missing ' +
+          '`duration` or `easing`. Sass drops declarations with null values, so the ' +
+          'motion would silently run with the initial 0s duration and never be seen.';
       }
     }
   }

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -724,9 +724,8 @@ $icon-hover-motion: (
   ),
 );
 
-// Conditional motion declarations must go through this mixin: the no-motion-outside-of-mixin
-// stylelint rule only accepts declarations sitting directly under `with-motion`, so an
-// intervening `@if` would trip it even though the output stays inside the gate.
+// Conditional motion declarations go through this mixin: the no-motion-outside-of-mixin
+// stylelint rule only accepts declarations directly under `with-motion`.
 @mixin _declarations($declarations) {
   @each $property, $value in $declarations {
     #{$property}: #{$value};
@@ -792,7 +791,6 @@ $icon-hover-motion: (
       }
     }
 
-    // Without a whole-icon spec, every spec has a `part`.
     @if not $whole-icon {
       $names: list.append($names, '.name-#{$name}', comma);
       @each $spec in _specs($specs) {
@@ -1193,22 +1191,18 @@ $_spec-keys: (part, animation, to, base, origin, duration, easing, delay, iterat
       @if (map.get($spec, animation) or map.get($spec, to)) and not
         (map.get($spec, duration) and map.get($spec, easing))
       {
-        @error 'The $icon-hover-motion spec for `#{$name}` sets motion but is missing ' +
-          '`duration` or `easing`. Sass drops declarations with null values, so the ' +
-          'motion would silently run with the initial 0s duration and never be seen.';
+        @error 'The $icon-hover-motion spec for `#{$name}` sets motion but is missing `duration` or `easing`.';
       }
     }
   }
 }
 
 @mixin icon-hover-motion {
-  @include _validate-specs;
-
+  @include _validate-specs; // checks if per-icon motion definitions are properly defined
   @include keyframes;
-
   @media (prefers-reduced-motion: no-preference) {
     @include generic-hover-motion;
-    @include _cancel-floor-under-hover-parts;
+    @include _cancel-floor-under-hover-parts; // ensures generic motion does not apply to icons with bespoke motion
     @include per-icon-hover-motion;
   }
 }

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -724,18 +724,10 @@ $icon-hover-motion: (
   ),
 );
 
-// The no-motion-outside-of-mixin stylelint rule checks literally written animation/transition
-// declarations, requiring `@include with-motion` as their direct parent. Dynamic declarations
-// emitted here are invisible to it — only call this inside `with-motion`.
-@mixin _declarations($declarations) {
-  @each $property, $value in $declarations {
-    #{$property}: #{$value};
-  }
-}
-
-// Motion declarations must sit directly under a mixin named *with-motion, per the
-// no-motion-outside-of-mixin stylelint rule. This is that mixin: it scopes @content
-// to opted-in themes and adds the runtime motion gate ($_motion-on).
+// Motion declarations must sit under a mixin named *with-motion, with at most sass
+// control flow in between, per the no-motion-outside-of-mixin stylelint rule. This is
+// that mixin: it scopes @content to opted-in themes and adds the runtime motion gate
+// ($_motion-on).
 @mixin with-motion {
   @include theming.expressive-motion-only($_motion-on) {
     @content;
@@ -835,16 +827,14 @@ $icon-hover-motion: (
         .icon.name-#{$name} #{$target} {
           @include with-motion {
             @if $to {
-              @include _declarations(
-                (
-                  transition-property: #{$property},
-                  transition-duration: $duration,
-                  transition-timing-function: $easing,
-                )
-              );
+              transition-property: #{$property};
+              transition-duration: $duration;
+              transition-timing-function: $easing;
             }
             @if $base {
-              @include _declarations($base);
+              @each $property, $value in $base {
+                #{$property}: #{$value};
+              }
             }
             @if $origin {
               transform-origin: $origin;
@@ -854,37 +844,24 @@ $icon-hover-motion: (
       }
 
       @include _on-hover-trigger('.icon#{$_animating-icon}.name-#{$name} #{$target}') {
-        @if $animation {
-          @include with-motion {
+        @include with-motion {
+          @if $animation {
             animation-name: $animation;
             animation-duration: $duration;
             animation-timing-function: $easing;
             @if $iterations != 1 {
-              @include _declarations(
-                (
-                  animation-iteration-count: $iterations,
-                )
-              );
+              animation-iteration-count: $iterations;
             }
             @if $fill != none {
-              @include _declarations(
-                (
-                  animation-fill-mode: $fill,
-                )
-              );
+              animation-fill-mode: $fill;
             }
             @if $delay != 0s {
-              @include _declarations(
-                (
-                  animation-delay: $delay,
-                )
-              );
+              animation-delay: $delay;
             }
-          }
-        }
-        @if $to {
-          @include with-motion {
-            @include _declarations($to);
+          } @else if $to {
+            @each $property, $value in $to {
+              #{$property}: #{$value};
+            }
           }
         }
       }

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -733,9 +733,9 @@ $icon-hover-motion: (
   }
 }
 
-// The one gate for motion declarations: theme opt-in plus the runtime motion gate
-// ($_motion-on), so no caller can get one without the other. Named with-motion because
-// the no-motion-outside-of-mixin stylelint rule matches callers by that name.
+// Motion declarations must sit directly under a mixin named *with-motion, per the
+// no-motion-outside-of-mixin stylelint rule. This is that mixin: it scopes @content
+// to opted-in themes and adds the runtime motion gate ($_motion-on).
 @mixin with-motion {
   @include theming.expressive-motion-only($_motion-on) {
     @content;

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -733,7 +733,9 @@ $icon-hover-motion: (
   }
 }
 
-// Named with-motion so the no-motion-outside-of-mixin stylelint rule can find callers.
+// The one gate for motion declarations: theme opt-in plus the runtime motion gate
+// ($_motion-on), so no caller can get one without the other. Named with-motion because
+// the no-motion-outside-of-mixin stylelint rule matches callers by that name.
 @mixin with-motion {
   @include theming.expressive-motion-only($_motion-on) {
     @content;

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -830,7 +830,6 @@ $icon-hover-motion: (
       $fill: map.get($spec, fill) or none;
       $delay: map.get($spec, delay) or 0s;
 
-      // base/origin are visually inert at rest, so riding inside the motion gate costs nothing.
       @if $to or $base or $origin {
         .icon.name-#{$name} #{$target} {
           @include with-motion {


### PR DESCRIPTION
### Description

Adds the logic to turn the icon motion map into emitted css. Extends spec validator for per-icon motion map. **No animations will be enabled by this**, as no components have been tagged with the respective data attribute. This will be a followup PR.

Related links, issue #, if available: `b9VcPdMJ5zRn`

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
