### PR TITLE
feat: add per-icon hover motion map and keyframes

### DIFF
--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -35,9 +35,975 @@ $_hover-trigger: '[#{$_trigger-attribute}~="hover"]#{$_enabled-only}';
 $_target-attribute: 'data-awsui-motion-target';
 $_animating-icon: ':is([#{$_target-attribute}], :where([#{$_target-attribute}] *))';
 
-// List for bespoke per-icon motion. An icon with no entry in `$icon-hover-motion`
-// gets the generic hover motion if the SVG is tagged with `data-awsui-icon-animated`.
-$icon-hover-motion: ();
+$_ease-out: ease-out;
+$_ease-symmetric: cubic-bezier(0.33, 0, 0.67, 1);
+$_ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+$icon-hover-motion: (
+  'announcement': (
+    (
+      duration: 400ms,
+      easing: $_ease-spring,
+      to: (
+        transform: rotate(-12deg) scale(0.84),
+      ),
+    ),
+  ),
+  'heart': (
+    (
+      animation: icon-pulse-soft,
+      duration: 450ms,
+      easing: $_ease-out,
+    ),
+  ),
+  'heart-filled': (
+    (
+      animation: icon-pulse-strong,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+  ),
+  'settings': (
+    (
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: rotate(60deg),
+      ),
+    ),
+  ),
+  'thumbs-up': (
+    (
+      duration: 400ms,
+      easing: $_ease-spring,
+      to: (
+        transform: rotate(-12deg) scale(0.92),
+      ),
+    ),
+  ),
+  'thumbs-up-filled': (
+    (
+      duration: 400ms,
+      easing: $_ease-spring,
+      to: (
+        transform: rotate(-12deg) scale(0.92),
+      ),
+    ),
+  ),
+  'thumbs-down': (
+    (
+      duration: 400ms,
+      easing: $_ease-spring,
+      to: (
+        transform: rotate(12deg) scale(0.92),
+      ),
+    ),
+  ),
+  'thumbs-down-filled': (
+    (
+      duration: 400ms,
+      easing: $_ease-spring,
+      to: (
+        transform: rotate(12deg) scale(0.92),
+      ),
+    ),
+  ),
+  'face-happy-filled': (
+    (
+      duration: 350ms,
+      easing: $_ease-spring,
+      to: (
+        transform: rotate(-3deg),
+      ),
+    ),
+  ),
+  'face-happy': (
+    (
+      duration: 350ms,
+      easing: $_ease-spring,
+      to: (
+        transform: rotate(-3deg),
+      ),
+    ),
+    (
+      part: 'awsui-icon-mouth',
+      animation: icon-mouth-smile-grow,
+      duration: 900ms,
+      easing: $_ease-symmetric,
+      base: (
+        stroke-dasharray: 7.4,
+        stroke-dashoffset: 0,
+      ),
+    ),
+  ),
+  'face-neutral': (
+    (
+      duration: 350ms,
+      easing: $_ease-spring,
+      to: (
+        transform: rotate(3deg),
+      ),
+    ),
+    (
+      part: 'awsui-icon-mouth',
+      animation: icon-mouth-tilt,
+      duration: 700ms,
+      easing: $_ease-symmetric,
+      origin: 8px 10px,
+    ),
+  ),
+  'face-sad': (
+    (
+      part: 'awsui-icon-mouth',
+      animation: icon-mouth-frown-deepen,
+      duration: 900ms,
+      easing: $_ease-symmetric,
+      base: (
+        stroke-dasharray: 7.4,
+        stroke-dashoffset: 0,
+      ),
+    ),
+  ),
+  'gen-ai': (
+    (
+      part: 'awsui-icon-sparkle',
+      animation: icon-sparkle-pinch,
+      duration: 500ms,
+      easing: ease,
+      origin: 50% center,
+      base: (
+        transform-box: fill-box,
+      ),
+    ),
+  ),
+  'search-gen-ai': (
+    (
+      part: 'awsui-icon-sparkle',
+      animation: icon-sparkle-pinch,
+      duration: 500ms,
+      easing: ease,
+      origin: 50% center,
+      base: (
+        transform-box: fill-box,
+      ),
+    ),
+  ),
+  'edit-gen-ai': (
+    (
+      part: 'awsui-icon-sparkle',
+      animation: icon-sparkle-pinch,
+      duration: 500ms,
+      easing: ease,
+      origin: 50% center,
+      base: (
+        transform-box: fill-box,
+      ),
+    ),
+  ),
+  'suggestions-gen-ai': (
+    (
+      part: 'awsui-icon-sparkle',
+      animation: icon-sparkle-pinch,
+      duration: 500ms,
+      easing: ease,
+      origin: 50% center,
+      base: (
+        transform-box: fill-box,
+      ),
+    ),
+  ),
+  'copy': (
+    (
+      part: 'awsui-icon-front',
+      duration: 150ms,
+      easing: $_ease-symmetric,
+      to: (
+        transform: translate(-4%, -4%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-back',
+      duration: 150ms,
+      easing: $_ease-symmetric,
+      to: (
+        transform: translate(4%, 4%),
+      ),
+    ),
+  ),
+  'refresh': (
+    (
+      part: 'awsui-icon-arc',
+      animation: icon-coil,
+      duration: 500ms,
+      easing: $_ease-symmetric,
+      origin: 8px 8px,
+    ),
+    (
+      part: 'awsui-icon-arrow',
+      animation: icon-coil-arrow,
+      duration: 500ms,
+      easing: $_ease-symmetric,
+      origin: 8px 8px,
+      base: (
+        stroke-dasharray: 0 0 10.01 0,
+      ),
+    ),
+  ),
+  'upload': (
+    (
+      part: 'awsui-icon-arrow',
+      animation: icon-nudge-up,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+  ),
+  'download': (
+    (
+      part: 'awsui-icon-arrow',
+      animation: icon-nudge-down,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+  ),
+  'upload-download': (
+    (
+      part: 'awsui-icon-up',
+      animation: icon-nudge-up-once,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+    (
+      part: 'awsui-icon-down',
+      animation: icon-nudge-down-once,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+  ),
+  'undo': (
+    (
+      part: 'awsui-icon-arrow',
+      animation: icon-nudge-back,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+    (
+      part: 'awsui-icon-line',
+      animation: icon-shaft-retract,
+      duration: 500ms,
+      easing: $_ease-out,
+      base: (
+        stroke-dasharray: 25.15,
+        stroke-dashoffset: 0,
+      ),
+    ),
+  ),
+  'redo': (
+    (
+      part: 'awsui-icon-arrow',
+      animation: icon-nudge-forward,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+    (
+      part: 'awsui-icon-line',
+      animation: icon-shaft-retract,
+      duration: 500ms,
+      easing: $_ease-out,
+      base: (
+        stroke-dasharray: 25.15,
+        stroke-dashoffset: 0,
+      ),
+    ),
+  ),
+  'external': (
+    (
+      part: 'awsui-icon-arrow',
+      animation: icon-nudge-up-right,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+  ),
+  'sign-out': (
+    (
+      part: 'awsui-icon-arrow',
+      animation: icon-nudge-in,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+  ),
+  'shrink': (
+    (
+      part: 'awsui-icon-corner-tr',
+      animation: icon-nudge-down-left,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+    (
+      part: 'awsui-icon-corner-bl',
+      animation: icon-nudge-up-right,
+      duration: 500ms,
+      easing: $_ease-out,
+    ),
+  ),
+  'expand': (
+    (
+      part: 'awsui-icon-corner-tl',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translate(-5%, -5%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-corner-tr',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translate(5%, -5%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-corner-bl',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translate(-5%, 5%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-corner-br',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translate(5%, 5%),
+      ),
+    ),
+  ),
+  'full-screen': (
+    (
+      part: 'awsui-icon-corner-tl',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translate(4%, 4%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-corner-tr',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translate(-4%, 4%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-corner-bl',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translate(4%, -4%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-corner-br',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translate(-4%, -4%),
+      ),
+    ),
+  ),
+  'exit-full-screen': (
+    (
+      part: 'awsui-icon-corner-tl',
+      duration: 500ms,
+      easing: $_ease-spring,
+      origin: 3.5px 3.5px,
+      to: (
+        transform: translate(5%, 5%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-corner-tr',
+      duration: 500ms,
+      easing: $_ease-spring,
+      origin: 12.5px 3.5px,
+      to: (
+        transform: translate(-5%, 5%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-corner-bl',
+      duration: 500ms,
+      easing: $_ease-spring,
+      origin: 3.5px 12.5px,
+      to: (
+        transform: translate(5%, -5%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-corner-br',
+      duration: 500ms,
+      easing: $_ease-spring,
+      origin: 12.5px 12.5px,
+      to: (
+        transform: translate(-5%, -5%),
+      ),
+    ),
+  ),
+  'remove': (
+    (
+      part: 'awsui-icon-lid',
+      duration: 500ms,
+      easing: $_ease-spring,
+      origin: 0px 100%,
+      base: (
+        transform-box: fill-box,
+      ),
+      to: (
+        transform: rotate(-4deg),
+      ),
+    ),
+    (
+      part: 'awsui-icon-side',
+      duration: 500ms,
+      easing: $_ease-spring,
+      origin: center bottom,
+      base: (
+        transform-box: fill-box,
+      ),
+      to: (
+        transform: scaleY(0.78),
+      ),
+    ),
+  ),
+  'zoom-to-fit': (
+    (
+      part: 'awsui-icon-square',
+      duration: 450ms,
+      easing: cubic-bezier(0.4, 0, 0.2, 1),
+      origin: 8px 8px,
+      to: (
+        transform: scale(1.15),
+      ),
+    ),
+  ),
+  'multiscreen': (
+    (
+      part: 'awsui-icon-front',
+      duration: 150ms,
+      easing: $_ease-symmetric,
+      to: (
+        transform: translate(-4%, -4%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-back',
+      duration: 150ms,
+      easing: $_ease-symmetric,
+      to: (
+        transform: translate(4%, 4%),
+      ),
+    ),
+  ),
+  'lock-private': (
+    (
+      part: 'awsui-icon-clip',
+      base: (
+        clip-path: inset(0 0 56.25% 0) view-box,
+      ),
+    ),
+    (
+      part: 'awsui-icon-shackle',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translateY(6.25%),
+      ),
+    ),
+  ),
+  'unlocked': (
+    (
+      part: 'awsui-icon-clip',
+      base: (
+        clip-path: inset(0 0 56.25% 0) view-box,
+      ),
+    ),
+    (
+      part: 'awsui-icon-shackle',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translateY(6.25%),
+      ),
+    ),
+  ),
+  'notification': (
+    (
+      part: 'awsui-icon-bell',
+      animation: icon-bell-rotate,
+      duration: 1000ms,
+      easing: ease-in-out,
+      origin: 8px 4px,
+    ),
+    (
+      part: 'awsui-icon-ringer',
+      animation: icon-ringer-bounce,
+      duration: 400ms,
+      easing: ease-in-out,
+      origin: 8px 12.25px,
+    ),
+  ),
+  'history': (
+    (
+      part: 'awsui-icon-hand',
+      duration: 450ms,
+      easing: $_ease-spring,
+      origin: 9px 9px,
+      to: (
+        transform: rotate(-45deg),
+      ),
+    ),
+  ),
+  'backward-10-seconds': (
+    (
+      part: 'awsui-icon-arc',
+      duration: 250ms,
+      easing: $_ease-out,
+      property: stroke-dashoffset,
+      base: (
+        stroke-dasharray: 30,
+        stroke-dashoffset: 0,
+      ),
+      to: (
+        stroke-dashoffset: -4px,
+      ),
+    ),
+    (
+      part: 'awsui-icon-one',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translateX(4%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-zero',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translateX(4%),
+      ),
+    ),
+  ),
+  'forward-10-seconds': (
+    (
+      part: 'awsui-icon-arc',
+      duration: 250ms,
+      easing: $_ease-out,
+      property: stroke-dashoffset,
+      base: (
+        stroke-dasharray: 30,
+        stroke-dashoffset: 0,
+      ),
+      to: (
+        stroke-dashoffset: -4px,
+      ),
+    ),
+    (
+      part: 'awsui-icon-one',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translateX(-4%),
+      ),
+    ),
+    (
+      part: 'awsui-icon-zero',
+      duration: 500ms,
+      easing: $_ease-spring,
+      to: (
+        transform: translateX(-4%),
+      ),
+    ),
+  ),
+  'view-horizontal': (
+    (
+      part: 'awsui-icon-panel',
+      duration: 450ms,
+      easing: cubic-bezier(0.4, 0, 0.2, 1),
+      origin: 8px 9.5px,
+      to: (
+        transform: scale(1.08),
+      ),
+    ),
+  ),
+  'view-vertical': (
+    (
+      part: 'awsui-icon-panel',
+      duration: 450ms,
+      easing: cubic-bezier(0.4, 0, 0.2, 1),
+      origin: 9.5px 8px,
+      to: (
+        transform: scale(1.08),
+      ),
+    ),
+  ),
+  'zoom-in': (
+    (
+      part: 'awsui-icon-arm',
+      duration: 450ms,
+      easing: cubic-bezier(0.4, 0, 0.2, 1),
+      origin: 7px 7px,
+      to: (
+        transform: scale(1.15),
+      ),
+    ),
+  ),
+  'zoom-out': (
+    (
+      part: 'awsui-icon-arm',
+      duration: 450ms,
+      easing: cubic-bezier(0.4, 0, 0.2, 1),
+      origin: 7px 7px,
+      to: (
+        transform: scale(0.85),
+      ),
+    ),
+  ),
+  'bug': (
+    (
+      part: 'awsui-icon-leg-tl',
+      animation: icon-gait-a,
+      duration: 600ms,
+      easing: $_ease-symmetric,
+      iterations: 2,
+      origin: 4px 5.71px,
+    ),
+    (
+      part: 'awsui-icon-leg-mr',
+      animation: icon-gait-a,
+      duration: 600ms,
+      easing: $_ease-symmetric,
+      iterations: 2,
+      origin: 12px 8.71px,
+    ),
+    (
+      part: 'awsui-icon-leg-bl',
+      animation: icon-gait-a,
+      duration: 600ms,
+      easing: $_ease-symmetric,
+      iterations: 2,
+      origin: 4px 11.71px,
+    ),
+    (
+      part: 'awsui-icon-leg-tr',
+      animation: icon-gait-b,
+      duration: 600ms,
+      easing: $_ease-symmetric,
+      iterations: 2,
+      origin: 12px 5.71px,
+    ),
+    (
+      part: 'awsui-icon-leg-ml',
+      animation: icon-gait-b,
+      duration: 600ms,
+      easing: $_ease-symmetric,
+      iterations: 2,
+      origin: 4px 8.71px,
+    ),
+    (
+      part: 'awsui-icon-leg-br',
+      animation: icon-gait-b,
+      duration: 600ms,
+      easing: $_ease-symmetric,
+      iterations: 2,
+      origin: 12px 11.71px,
+    ),
+  ),
+);
+
+// @keyframes cannot nest under a class, so they're gated on the artefact instead of the selector.
+@mixin keyframes {
+  @if theming.has-expressive-motion() {
+    @keyframes icon-pulse-soft {
+      0% {
+        transform: scale(1);
+      }
+      22% {
+        transform: scale(0.85);
+      }
+      44% {
+        transform: scale(1);
+      }
+      67% {
+        transform: scale(0.9);
+      }
+      100% {
+        transform: scale(1);
+      }
+    }
+
+    @keyframes icon-pulse-strong {
+      0%,
+      100% {
+        transform: scale(1);
+      }
+      40% {
+        transform: scale(0.9);
+      }
+    }
+
+    @keyframes icon-mouth-frown-deepen {
+      0%,
+      100% {
+        stroke-dasharray: 7.4;
+        stroke-dashoffset: 0;
+      }
+      50% {
+        stroke-dasharray: 6, 7.4;
+        stroke-dashoffset: -0.7px;
+      }
+    }
+
+    @keyframes icon-mouth-smile-grow {
+      0%,
+      100% {
+        stroke-dasharray: 7.4;
+        stroke-dashoffset: 0;
+      }
+      50% {
+        stroke-dasharray: 6, 7.4;
+        stroke-dashoffset: -0.7px;
+      }
+    }
+
+    @keyframes icon-mouth-tilt {
+      0%,
+      100% {
+        transform: rotate(0deg);
+      }
+      35%,
+      65% {
+        transform: rotate(-4deg);
+      }
+    }
+
+    @keyframes icon-nudge-up {
+      0%,
+      40%,
+      80%,
+      100% {
+        transform: translateY(0);
+      }
+      20%,
+      60% {
+        transform: translateY(-8%);
+      }
+    }
+
+    @keyframes icon-nudge-down {
+      0%,
+      40%,
+      80%,
+      100% {
+        transform: translateY(0);
+      }
+      20%,
+      60% {
+        transform: translateY(8%);
+      }
+    }
+
+    @keyframes icon-nudge-up-once {
+      0%,
+      100% {
+        transform: translateY(0);
+      }
+      45% {
+        transform: translateY(-8%);
+      }
+    }
+
+    @keyframes icon-nudge-down-once {
+      0%,
+      100% {
+        transform: translateY(0);
+      }
+      45% {
+        transform: translateY(8%);
+      }
+    }
+
+    @keyframes icon-nudge-back {
+      0%,
+      40%,
+      80%,
+      100% {
+        transform: translateX(0);
+      }
+      20%,
+      60% {
+        transform: translateX(14%);
+      }
+    }
+
+    @keyframes icon-nudge-forward {
+      0%,
+      40%,
+      80%,
+      100% {
+        transform: translateX(0);
+      }
+      20%,
+      60% {
+        transform: translateX(-14%);
+      }
+    }
+
+    @keyframes icon-shaft-retract {
+      0%,
+      40%,
+      80%,
+      100% {
+        stroke-dashoffset: 0;
+      }
+      20%,
+      60% {
+        stroke-dashoffset: -2.24px;
+      }
+    }
+
+    @keyframes icon-nudge-in {
+      0%,
+      40%,
+      80%,
+      100% {
+        transform: translateX(0);
+      }
+      20%,
+      60% {
+        transform: translateX(-8%);
+      }
+    }
+
+    @keyframes icon-nudge-up-right {
+      0%,
+      40%,
+      80%,
+      100% {
+        transform: translate(0, 0);
+      }
+      20%,
+      60% {
+        transform: translate(5%, -5%);
+      }
+    }
+
+    @keyframes icon-nudge-down-left {
+      0%,
+      40%,
+      80%,
+      100% {
+        transform: translate(0, 0);
+      }
+      20%,
+      60% {
+        transform: translate(-5%, 5%);
+      }
+    }
+
+    @keyframes icon-gait-a {
+      0%,
+      100% {
+        transform: rotate(0deg);
+      }
+      50% {
+        transform: rotate(-8deg);
+      }
+    }
+
+    @keyframes icon-gait-b {
+      0%,
+      100% {
+        transform: rotate(0deg);
+      }
+      50% {
+        transform: rotate(8deg);
+      }
+    }
+
+    @keyframes icon-sparkle-pinch {
+      0%,
+      100% {
+        transform: scale(1);
+      }
+      40% {
+        transform: scale(0.8) rotate(-15deg);
+      }
+    }
+
+    @keyframes icon-bell-rotate {
+      0%,
+      100% {
+        transform: rotate(0deg);
+      }
+      20% {
+        transform: rotate(8deg);
+      }
+      40% {
+        transform: rotate(-6deg);
+      }
+      60% {
+        transform: rotate(4deg);
+      }
+      80% {
+        transform: rotate(-2deg);
+      }
+    }
+
+    @keyframes icon-ringer-bounce {
+      0%,
+      100% {
+        transform: translateX(0);
+      }
+      20% {
+        transform: translateX(5%);
+      }
+      40% {
+        transform: translateX(-5%);
+      }
+      60% {
+        transform: translateX(2.5%);
+      }
+      80% {
+        transform: translateX(-1.5%);
+      }
+    }
+
+    @keyframes icon-coil {
+      0%,
+      100% {
+        transform: rotate(0deg);
+      }
+      55% {
+        transform: rotate(-14deg);
+      }
+    }
+
+    @keyframes icon-coil-arrow {
+      0%,
+      100% {
+        stroke-dasharray: 0 0 10.01 0;
+        transform: rotate(0deg);
+      }
+      55% {
+        stroke-dasharray: 0 2 6.01 2;
+        transform: rotate(-14deg);
+      }
+    }
+  }
+}
 
 // Named with-motion so the no-motion-outside-of-mixin stylelint rule can find callers.
 @mixin with-motion {

--- a/src/icon/icons/history.svg
+++ b/src/icon/icons/history.svg
@@ -1,5 +1,6 @@
 <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 <path d="M1 0L1 5L6 4.95999" class="stroke-linejoin-round"/>
 <path d="M1 8C1 11.87 4.13 15 8 15C11.87 15 15 11.87 15 8C15 4.13 11.87 1 8 1C5.21 1 2.80001 2.63 1.67001 5" />
-<path d="M9 4V9H5" class="stroke-linejoin-round awsui-icon-hands"/>
+<path d="M9 4V9" class="stroke-linejoin-round"/>
+<path d="M9 9H5" class="stroke-linejoin-round awsui-icon-hand"/>
 </svg>

--- a/src/icon/icons/lock-private.svg
+++ b/src/icon/icons/lock-private.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 <path d="M12 7H4C3.44772 7 3 7.44772 3 8V14C3 14.5523 3.44772 15 4 15H12C12.5523 15 13 14.5523 13 14V8C13 7.44772 12.5523 7 12 7Z" class="stroke-linejoin-round"/>
-<path d="M5 7V4C5 2.35 6.35 1 8 1C9.65 1 11 2.35 11 4V7" class="stroke-linejoin-round awsui-icon-shackle"/>
+<g class="awsui-icon-clip"><path d="M5 7V4C5 2.35 6.35 1 8 1C9.65 1 11 2.35 11 4V7" class="stroke-linejoin-round awsui-icon-shackle"/></g>
 </svg>

--- a/src/icon/icons/multiscreen.svg
+++ b/src/icon/icons/multiscreen.svg
@@ -1,6 +1,6 @@
 <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 <path class="stroke-linejoin-round awsui-icon-front" d="M15 5H5V12H15V5Z" />
 <path class="stroke-linejoin-round awsui-icon-back" d="M11 3V1.01001L1.01 1L1 8H2.998" />
-<path class="stroke-linejoin-round awsui-icon-foot" d="M10 12V15" />
-<path class="stroke-linejoin-round awsui-icon-foot" d="M7 15H13" />
+<path class="stroke-linejoin-round awsui-icon-front" d="M10 12V15" />
+<path class="stroke-linejoin-round awsui-icon-front" d="M7 15H13" />
 </svg>

--- a/src/icon/icons/remove.svg
+++ b/src/icon/icons/remove.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-<path d="M1 5H15" class="stroke-linejoin-round"/>
-<path d="M13 5L12 15H4L3 5" class="stroke-linejoin-round"/>
-<path d="M5 5V2H11V5" class="stroke-linejoin-round"/>
+<path d="M1 5H15" class="stroke-linejoin-round awsui-icon-lid"/>
+<path d="M13 5L12 15H4L3 5" class="stroke-linejoin-round awsui-icon-side"/>
+<path d="M5 5V2H11V5" class="stroke-linejoin-round awsui-icon-lid"/>
 </svg>

--- a/src/icon/icons/unlocked.svg
+++ b/src/icon/icons/unlocked.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 <path d="M11 7H3C2.44772 7 2 7.44772 2 8V14C2 14.5523 2.44772 15 3 15H11C11.5523 15 12 14.5523 12 14V8C12 7.44772 11.5523 7 11 7Z" class="stroke-linejoin-round"/>
-<path d="M9 7V4C9 2.35 10.35 1 12 1C13.65 1 15 2.35 15 4" class="stroke-linejoin-round awsui-icon-shackle"/>
+<g class="awsui-icon-clip"><path d="M9 7V4C9 2.35 10.35 1 12 1C13.65 1 15 2.35 15 4" class="stroke-linejoin-round awsui-icon-shackle"/></g>
 </svg>


### PR DESCRIPTION
### Description

Fills the animation map with icon-specific motions and introduces necessary keyframes. Icon motion is not enabled yet, so **this PR does not introduce any visual changes**. 

Also adds necessary icon-part tags to three icons as a follow up to https://github.com/cloudscape-design/components/pull/4919

Related links, issue #, if available: `b9VcPdMJ5zRn`

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
