### PR TITLE
chore: Fix ColumnDisplay same column and group id crash

### DIFF
--- a/pages/table/column-groups.page.tsx
+++ b/pages/table/column-groups.page.tsx
@@ -77,9 +77,10 @@ const groupDefinitions: TableProps.GroupDefinition[] = [
   { id: 'performance', header: 'Performance' },
   { id: 'network', header: 'Network' },
   { id: 'metrics', header: 'Metrics' },
+  { id: 'type', header: 'Type Details' },
 ];
 
-type GroupingPreset = 'flat' | 'single-level' | 'nested' | 'single-child-groups';
+type GroupingPreset = 'flat' | 'single-level' | 'nested' | 'single-child-groups' | 'id-collision';
 
 const columnDisplayPresets: Record<GroupingPreset, TableProps.ColumnDisplayProperties[]> = {
   flat: [
@@ -179,6 +180,30 @@ const columnDisplayPresets: Record<GroupingPreset, TableProps.ColumnDisplayPrope
     { id: 'netOut', visible: true },
     { id: 'cost', visible: true },
   ],
+  'id-collision': [
+    { id: 'id', visible: true },
+    { id: 'name', visible: true },
+    {
+      type: 'group',
+      id: 'type',
+      visible: true,
+      children: [
+        { id: 'type', visible: true },
+        { id: 'az', visible: true },
+        { id: 'state', visible: true },
+      ],
+    },
+    {
+      type: 'group',
+      id: 'performance',
+      visible: true,
+      children: [
+        { id: 'cpu', visible: true },
+        { id: 'memory', visible: true },
+      ],
+    },
+    { id: 'cost', visible: true },
+  ],
 };
 
 const presetOptions = [
@@ -186,6 +211,7 @@ const presetOptions = [
   { value: 'nested', label: 'Nested groups (3 levels)' },
   { value: 'single-child-groups', label: 'Single-child groups' },
   { value: 'flat', label: 'Without grouping' },
+  { value: 'id-collision', label: 'Column id = group id' },
 ];
 
 type DemoContext = React.Context<

--- a/src/table/column-groups/__tests__/utils.test.ts
+++ b/src/table/column-groups/__tests__/utils.test.ts
@@ -248,5 +248,33 @@ describe('calculateHierarchyTree', () => {
       const result = calculateHierarchyTree(COLUMN_DEFS, [], groups, display);
       expect(result.rows).toHaveLength(0);
     });
+
+    test('renders table when a column has the same id as its group', () => {
+      const cols: TableProps.ColumnDefinition<any>[] = [
+        { id: 'id', header: 'ID', cell: () => 'id' },
+        { id: 'target', header: 'Target', cell: () => 'target' },
+        { id: 'processingTime', header: 'Processing time', cell: () => 'processingTime' },
+      ];
+      const groups: TableProps.GroupDefinition[] = [{ id: 'target', header: 'Target details' }];
+      const display: TableProps.ColumnDisplayProperties[] = [
+        { id: 'id', visible: true },
+        {
+          type: 'group',
+          id: 'target',
+          visible: true,
+          children: [
+            { id: 'target', visible: true },
+            { id: 'processingTime', visible: true },
+          ],
+        },
+      ];
+      const result = calculateHierarchyTree(cols, ['id', 'target', 'processingTime'], groups, display);
+
+      expect(result.maxDepth).toBe(2);
+      expect(result.rows).toHaveLength(2);
+      expect(result.rows[0].columns.map(c => c.id)).toEqual(['id', 'target']);
+      expect(result.rows[0].columns.find(c => c.id === 'target')).toMatchObject({ isGroup: true, colSpan: 2 });
+      expect(result.rows[1].columns.map(c => c.id)).toEqual(['target', 'processingTime']);
+    });
   });
 });

--- a/src/table/column-groups/utils.ts
+++ b/src/table/column-groups/utils.ts
@@ -7,6 +7,7 @@ import { getVisibleColumnDefinitions } from '../utils';
 
 export interface HeaderRowColumn<T> {
   id: string;
+  cellKey: string;
   header?: React.ReactNode;
   colSpan: number;
   rowSpan: number;
@@ -89,17 +90,18 @@ export class TableHeaderNode<T> {
  */
 function buildTreeFromColumnDisplay<T>(
   displayItems: ReadonlyArray<TableProps.ColumnDisplayProperties>,
-  nodeMap: Map<string, TableHeaderNode<T>>,
+  columnNodeMap: Map<string, TableHeaderNode<T>>,
+  groupNodeMap: Map<string, TableHeaderNode<T>>,
   parent: TableHeaderNode<T>
 ): void {
   for (const item of displayItems) {
     if (item.type === 'group') {
-      const groupNode = nodeMap.get(item.id);
+      const groupNode = groupNodeMap.get(item.id);
       if (!groupNode) {
         warnOnce('[Table]', `Group "${item.id}" referenced in columnDisplay not found in groupDefinitions. Skipping.`);
         continue;
       }
-      buildTreeFromColumnDisplay(item.children, nodeMap, groupNode);
+      buildTreeFromColumnDisplay(item.children, columnNodeMap, groupNodeMap, groupNode);
       // Only attach group if it has visible descendants. The recursive call above
       // only adds children that are either visible columns or nested groups with
       // their own visible descendants, so this check handles all nesting levels.
@@ -110,7 +112,7 @@ function buildTreeFromColumnDisplay<T>(
       if (!item.visible) {
         continue;
       }
-      const colNode = nodeMap.get(item.id);
+      const colNode = columnNodeMap.get(item.id);
       if (colNode) {
         parent.addChild(colNode);
       }
@@ -123,7 +125,7 @@ function buildTreeFromColumnDisplay<T>(
  */
 function buildTreeFromVisibleColumns<T>(
   visibleColumns: Readonly<TableProps.ColumnDefinition<T>[]>,
-  nodeMap: Map<string, TableHeaderNode<T>>,
+  columnNodeMap: Map<string, TableHeaderNode<T>>,
   root: TableHeaderNode<T>
 ): void {
   for (const col of visibleColumns) {
@@ -132,7 +134,7 @@ function buildTreeFromVisibleColumns<T>(
     if (!col.id) {
       continue;
     }
-    const node = nodeMap.get(col.id);
+    const node = columnNodeMap.get(col.id);
     if (node) {
       root.addChild(node);
     }
@@ -191,24 +193,25 @@ export function calculateHierarchyTree<T>(
     columnDefinitions,
   });
 
-  const nodeMap = new Map<string, TableHeaderNode<T>>();
+  const columnNodeMap = new Map<string, TableHeaderNode<T>>();
+  const groupNodeMap = new Map<string, TableHeaderNode<T>>();
 
   for (const col of visibleColumns) {
     if (col.id) {
-      nodeMap.set(col.id, new TableHeaderNode<T>(col.id, { columnDefinition: col }));
+      columnNodeMap.set(col.id, new TableHeaderNode<T>(col.id, { columnDefinition: col }));
     }
   }
 
   for (const group of groupDefinitions) {
-    nodeMap.set(group.id, new TableHeaderNode<T>(group.id, { groupDefinition: group }));
+    groupNodeMap.set(group.id, new TableHeaderNode<T>(group.id, { groupDefinition: group }));
   }
 
   const root = new TableHeaderNode<T>('*', { isRoot: true });
 
   if (columnDisplay && columnDisplay.length > 0) {
-    buildTreeFromColumnDisplay(columnDisplay, nodeMap, root);
+    buildTreeFromColumnDisplay(columnDisplay, columnNodeMap, groupNodeMap, root);
   } else {
-    buildTreeFromVisibleColumns(visibleColumns, nodeMap, root);
+    buildTreeFromVisibleColumns(visibleColumns, columnNodeMap, root);
   }
 
   computeSubTreeHeights(root);
@@ -249,6 +252,7 @@ function buildOutput<T>(root: TableHeaderNode<T>, maxDepth: number): ColumnGroup
 
     const entry: HeaderRowColumn<T> = {
       id: node.id,
+      cellKey: node.isGroup ? `group:${node.id}` : `column:${node.id}`,
       header: node.groupDefinition?.header ?? node.columnDefinition?.header,
       colSpan: node.colSpan,
       rowSpan: node.rowSpan,

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -310,7 +310,7 @@ const Thead = React.forwardRef(
                   const rightChildIds = childIds.slice(leftColspan);
 
                   return (
-                    <React.Fragment key={col.id}>
+                    <React.Fragment key={col.cellKey}>
                       {/* Left half */}
                       <TableGroupHeaderCell
                         {...sharedGroupCellProps}
@@ -324,7 +324,7 @@ const Thead = React.forwardRef(
                         childColumnIds={leftChildIds}
                         firstChildColumnId={leftChildIds[0]}
                         lastChildColumnId={leftChildIds[leftChildIds.length - 1]}
-                        cellRef={isSplitFirst ? node => setCell(sticky, col.id, node) : () => {}}
+                        cellRef={isSplitFirst ? node => setCell(sticky, col.cellKey, node) : () => {}}
                         isLast={false}
                         stickyColumnId={isSplitFirst ? childIds[0] : undefined}
                         stickyBoundaryColumnId={isSplitFirst ? leftChildIds[leftChildIds.length - 1] : undefined}
@@ -336,14 +336,14 @@ const Thead = React.forwardRef(
                         colspan={rightColspan}
                         colIndex={selectionType ? rightColIndex + 1 : rightColIndex}
                         groupId={rightGroupId}
-                        resizableStyle={getColumnStyles(sticky, col.id)}
+                        resizableStyle={getColumnStyles(sticky, col.cellKey)}
                         updateGroupWidth={(_, newWidth) => {
                           handleSplitGroupResize(rightChildIds, newWidth);
                         }}
                         childColumnIds={rightChildIds}
                         firstChildColumnId={rightChildIds[0]}
                         lastChildColumnId={rightChildIds[rightChildIds.length - 1]}
-                        cellRef={!isSplitFirst ? node => setCell(sticky, col.id, node) : () => {}}
+                        cellRef={!isSplitFirst ? node => setCell(sticky, col.cellKey, node) : () => {}}
                         resizerRoleDescription={resizerRoleDescription}
                         resizerTooltipText={resizerTooltipText}
                         isLast={rightColIndex + rightColspan === totalColumns}
@@ -380,18 +380,18 @@ const Thead = React.forwardRef(
                 return (
                   <TableGroupHeaderCell
                     {...sharedGroupCellProps}
-                    key={col.id}
+                    key={col.cellKey}
                     colspan={col.colSpan}
                     colIndex={selectionType ? col.colIndex + 1 : col.colIndex}
                     groupId={col.id}
-                    resizableStyle={getColumnStyles(sticky, col.id)}
+                    resizableStyle={getColumnStyles(sticky, col.cellKey)}
                     updateGroupWidth={(groupId, newWidth) => {
                       updateGroup(groupId, newWidth);
                     }}
                     childColumnIds={childIds}
                     firstChildColumnId={childIds[0]}
                     lastChildColumnId={childIds[childIds.length - 1]}
-                    cellRef={node => setCell(sticky, col.id, node)}
+                    cellRef={node => setCell(sticky, col.cellKey, node)}
                     resizerRoleDescription={resizerRoleDescription}
                     resizerTooltipText={resizerTooltipText}
                     isLast={col.colIndex + col.colSpan === totalColumns}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
A column id matching a group id caused calculateHierarchyTree to add the group node as a child of itself, triggering infinite recursion in computeSubTreeHeights (RangeError: Maximum call stack size exceeded).

Fix: use separate maps for column nodes and group nodes so the two namespaces never collide.


<!-- Also include relevant motivation and context. -->

Related links, AWSUI-62239

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
