### PR TITLE
fix: Align loading spinner with status icons in Steps

### DIFF
--- a/src/spinner/internal.tsx
+++ b/src/spinner/internal.tsx
@@ -11,7 +11,12 @@ import { SpinnerProps } from './interfaces';
 
 import styles from './styles.css.js';
 
-interface InternalSpinnerProps extends SpinnerProps, InternalBaseComponentProps {}
+// `x-small` is intentionally internal-only: it matches One Theme's x-small status icons and is not part of the public Spinner API
+type InternalSpinnerSize = SpinnerProps.Size | 'x-small';
+
+interface InternalSpinnerProps extends Omit<SpinnerProps, 'size'>, InternalBaseComponentProps {
+  size?: InternalSpinnerSize;
+}
 
 export default function InternalSpinner({
   size = 'normal',

--- a/src/spinner/mixins.scss
+++ b/src/spinner/mixins.scss
@@ -10,7 +10,7 @@
 $_spinner-sizes: (
   (
     name: 'x-small',
-    size: 0.9 * styles.$base-size,
+    size: styles.$base-size,
     iconSizeMap: 12px,
     supportedLineHeight: awsui.$line-height-body-s,
   ),

--- a/src/spinner/mixins.scss
+++ b/src/spinner/mixins.scss
@@ -9,6 +9,12 @@
 
 $_spinner-sizes: (
   (
+    name: 'x-small',
+    size: 0.9 * styles.$base-size,
+    iconSizeMap: 12px,
+    supportedLineHeight: awsui.$line-height-body-s,
+  ),
+  (
     name: 'normal',
     size: 1.2 * styles.$base-size,
     iconSizeMap: awsui.$size-icon-normal,

--- a/src/spinner/styles.scss
+++ b/src/spinner/styles.scss
@@ -60,11 +60,6 @@
     border-inline: 0.2 * styles.$base-size solid;
     border-inline-end-color: transparent;
     border-block-end-color: transparent;
-
-    @include theming.one-theme-only {
-      border-block-width: awsui.$border-width-icon-x-small;
-      border-inline-width: awsui.$border-width-icon-x-small;
-    }
   }
 }
 
@@ -119,5 +114,17 @@
     inset-inline-start: -100%;
     /*stylelint-disable-next-line @cloudscape-design/no-motion-outside-of-mixin */
     animation-name: spinner-line-right;
+  }
+}
+
+// One Theme renders x-small/normal status icons with a 1.5px stroke.
+// Match the spinner ring for those sizes only; big/large keep 2px.
+.root.size-x-small,
+.root.size-normal {
+  @include theming.one-theme-only {
+    & > .circle::after {
+      border-block-width: awsui.$border-width-icon-x-small;
+      border-inline-width: awsui.$border-width-icon-x-small;
+    }
   }
 }

--- a/src/spinner/styles.scss
+++ b/src/spinner/styles.scss
@@ -7,6 +7,7 @@
 @use './mixins' as mixins;
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/generated/custom-css-properties/index' as custom-props;
+@use '../internal/styles/utils/theming' as theming;
 
 @keyframes spinner-rotator {
   0% {
@@ -59,6 +60,11 @@
     border-inline: 0.2 * styles.$base-size solid;
     border-inline-end-color: transparent;
     border-block-end-color: transparent;
+
+    @include theming.one-theme-only {
+      border-block-width: awsui.$border-width-icon-x-small;
+      border-inline-width: awsui.$border-width-icon-x-small;
+    }
   }
 }
 

--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -38,18 +38,23 @@ export interface InternalStatusIndicatorProps
   __display?: 'inline' | 'inline-block';
 }
 
-const typeToIcon: (size: IconProps.Size) => Record<StatusIndicatorProps.Type, JSX.Element> = size => ({
-  error: <InternalIcon name="status-negative" size={size} />,
-  warning: <InternalIcon name="status-warning" size={size} />,
-  success: <InternalIcon name="status-positive" size={size} />,
-  info: <InternalIcon name="status-info" size={size} />,
-  stopped: <InternalIcon name="status-stopped" size={size} />,
-  pending: <InternalIcon name="status-pending" size={size} />,
-  'in-progress': <InternalIcon name="status-in-progress" size={size} />,
-  loading: <InternalSpinner />,
-  'not-started': <InternalIcon name="status-not-started" size={size} />,
-  log: <InternalIcon name="dot" size={size} />,
-});
+const typeToIcon: (size: IconProps.Size) => Record<StatusIndicatorProps.Type, JSX.Element> = size => {
+  // Spinner supports a narrower size set than icons (no 'small'/'medium'/'inherit'); map to a valid
+  // spinner size so the loading spinner matches the sibling status icons.
+  const spinnerSize = size === 'x-small' ? 'x-small' : 'normal';
+  return {
+    error: <InternalIcon name="status-negative" size={size} />,
+    warning: <InternalIcon name="status-warning" size={size} />,
+    success: <InternalIcon name="status-positive" size={size} />,
+    info: <InternalIcon name="status-info" size={size} />,
+    stopped: <InternalIcon name="status-stopped" size={size} />,
+    pending: <InternalIcon name="status-pending" size={size} />,
+    'in-progress': <InternalIcon name="status-in-progress" size={size} />,
+    loading: <InternalSpinner size={spinnerSize} />,
+    'not-started': <InternalIcon name="status-not-started" size={size} />,
+    log: <InternalIcon name="dot" size={size} />,
+  };
+};
 
 interface InternalStatusIconProps extends Pick<InternalStatusIndicatorProps, 'type' | 'iconAriaLabel'> {
   animate?: InternalStatusIndicatorProps['__animate'];


### PR DESCRIPTION
### Description

In the Steps component (vertical orientation, One Theme), the loading spinner and the header text didn't align with the other steps' status icons (e.g., the ✓ success icon). The spinner sat slightly off and its header text started at a different x-position.

Root cause: the status indicator renders its icon inline with the text, so alignment depends on the icon glyph occupying a consistent size. In One Theme, status icons render at x-small (12px), but the spinner had no x-small size — its smallest was normal (16px). So next to 12px icons the spinner was oversized and misaligned. Additionally, the loading entry never passed size to the spinner at all (<InternalSpinner />), so it always defaulted to normal.

### How has this been tested?

Screenshot tests

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
