### PR TITLE
fix: restore the join at history's clock-hand spindle

### DIFF
--- a/src/icon/icons/history.svg
+++ b/src/icon/icons/history.svg
@@ -3,4 +3,5 @@
 <path d="M1 8C1 11.87 4.13 15 8 15C11.87 15 15 11.87 15 8C15 4.13 11.87 1 8 1C5.21 1 2.80001 2.63 1.67001 5" />
 <path d="M9 4V9" class="stroke-linejoin-round"/>
 <path d="M9 9H5" class="stroke-linejoin-round awsui-icon-hand"/>
+<path d="M9 9h0.01" class="stroke-linecap-round"/>
 </svg>


### PR DESCRIPTION
Fixes a regression where the hands don't meet in the history icon:

<img width="82" height="82" alt="image" src="https://github.com/user-attachments/assets/46b54797-f9fe-459d-ae0c-ed54197ad18c" />


### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
