### PR TITLE
chore: Use doubleClick method from browser-test-tools in date range picker test

### DIFF
--- a/test/definitions/visual/date-range-picker.ts
+++ b/test/definitions/visual/date-range-picker.ts
@@ -83,17 +83,12 @@ const suite: TestSuite = {
       description: 'does not select text when double-clicking next button',
       path: 'date-range-picker/with-value',
       screenshotType: 'screenshotArea',
-      setup: async ({ page, wrapper, browser }) => {
+      setup: async ({ page, wrapper }) => {
         await page.click('#focusable-before');
         await page.focusNextElement();
         await page.keys(['Enter']);
         const nextButtonSelector = wrapper.findDateRangePicker().findDropdown().findNextMonthButton().toSelector();
-        await browser!.execute((sel: string) => {
-          const el = document.querySelector(sel);
-          if (el) {
-            el.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
-          }
-        }, nextButtonSelector);
+        await page.doubleClick(nextButtonSelector);
       },
     },
   ],

--- a/test/definitions/visual/date-range-picker.ts
+++ b/test/definitions/visual/date-range-picker.ts
@@ -87,7 +87,7 @@ const suite: TestSuite = {
         await page.click('#focusable-before');
         await page.focusNextElement();
         await page.keys(['Enter']);
-        const nextButtonSelector = wrapper.findDateRangePicker().findDropdown().findNextMonthButton().toSelector();
+        const nextButtonSelector = wrapper.findDateRangePicker().findDropdown().findNextButton().toSelector();
         await page.doubleClick(nextButtonSelector);
       },
     },


### PR DESCRIPTION
### Description

The date range picker test "does not select text when double-clicking next button" fails in the internal pipeline because the `browser` is not passed to the `setup` callback. But the best way to address this is to use the `doubleClick` method added to browser-test-tools in https://github.com/cloudscape-design/browser-test-tools/pull/243 (just the same as we do in the previous test, actually), so the `browser` is not necessary at all.

### How has this been tested?

Checks in this PR

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
