### PR TITLE
refactor: apply usePortalModeClasses to remaining portaled components

### DIFF
--- a/src/__tests__/functional-tests/ssr.test.ts
+++ b/src/__tests__/functional-tests/ssr.test.ts
@@ -26,11 +26,12 @@ const vrOnlyComponents = ['app-layout-toolbar'];
 
 // Components whose entire tree is rendered through a portal. The server renderer has no
 // container to portal into, so none of their content reaches the server markup. Portal
-// itself renders a hidden placeholder element in its place, so that the markup matches
+// itself may render a hidden placeholder element in its place, so that the markup matches
 // the first client render and hydration succeeds; the client replaces it on the first
-// commit. Older component-toolkit versions emit nothing at all, hence the optional match.
+// commit. Some components also render their own hidden source anchor to detect inherited
+// portal-mode classes, and older component-toolkit versions emit nothing at all.
 const portaledComponents = ['modal', 'tooltip'];
-const emptyOrHiddenPlaceholder = /^(<span style="display:none"><\/span>)?$/;
+const emptyOrHiddenPlaceholder = /^(<span hidden=""><\/span>)?(<span style="display:none"><\/span>)?$/;
 
 test('ensure is it not DOM', () => {
   expect(typeof window).toBe('undefined');

--- a/src/annotation-context/__tests__/annotation-context.test.tsx
+++ b/src/annotation-context/__tests__/annotation-context.test.tsx
@@ -261,6 +261,25 @@ test('trigger should have aria-expanded depending on open state', () => {
   expect(hotspot.findTrigger().getElement().getAttribute('aria-expanded')).toBe('false');
 });
 
+test('propagates one-theme class to the portaled annotation when one theme is active', () => {
+  const themeRoot = document.createElement('div');
+  themeRoot.className = 'awsui-one-theme';
+  document.body.appendChild(themeRoot);
+
+  try {
+    const { wrapper } = renderAnnotationContext(<Hotspot hotspotId="first-hotspot" />);
+    expect(wrapper.findAnnotation()!.findContent().getElement().closest('.awsui-one-theme')).not.toBeNull();
+  } finally {
+    themeRoot.remove();
+  }
+});
+
+test('does not stamp one-theme class on the portaled annotation when one theme is inactive', () => {
+  const { wrapper } = renderAnnotationContext(<Hotspot hotspotId="first-hotspot" />);
+
+  expect(wrapper.findAnnotation()!.findContent().getElement().closest('.awsui-one-theme')).toBeNull();
+});
+
 test('annotation should have be labeled by header and step counter', () => {
   const { wrapper } = renderAnnotationContext(
     <>

--- a/src/annotation-context/__tests__/annotation-context.test.tsx
+++ b/src/annotation-context/__tests__/annotation-context.test.tsx
@@ -5,6 +5,7 @@ import { render } from '@testing-library/react';
 
 import AnnotationContext from '../../../lib/components/annotation-context';
 import Hotspot from '../../../lib/components/hotspot';
+import VisualContext from '../../../lib/components/internal/components/visual-context';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { AnnotationContextProps } from '../interfaces';
 import { getTutorial, getTutorialWithMultipleStepsPerHotspot, i18nStrings } from './data';
@@ -278,6 +279,19 @@ test('does not stamp one-theme class on the portaled annotation when one theme i
   const { wrapper } = renderAnnotationContext(<Hotspot hotspotId="first-hotspot" />);
 
   expect(wrapper.findAnnotation()!.findContent().getElement().closest('.awsui-one-theme')).toBeNull();
+});
+
+test('does not propagate visual context to the portaled annotation', () => {
+  const { wrapper } = renderAnnotationContext(
+    <div className="awsui-polaris-dark-mode">
+      <VisualContext contextName="alert">
+        <Hotspot hotspotId="first-hotspot" />
+      </VisualContext>
+    </div>
+  );
+
+  expect(wrapper.findAnnotation()!.findContent().getElement().closest('.awsui-polaris-dark-mode')).not.toBeNull();
+  expect(wrapper.findAnnotation()!.findContent().getElement().closest('.awsui-context-alert')).toBeNull();
 });
 
 test('annotation should have be labeled by header and step counter', () => {

--- a/src/annotation-context/annotation/open-annotation.tsx
+++ b/src/annotation-context/annotation/open-annotation.tsx
@@ -62,7 +62,7 @@ export function OpenAnnotation({
   i18nStrings,
 }: AnnotationProps) {
   const trackRef = useRef<HTMLButtonElement>(null);
-  const portalClasses = usePortalModeClasses(trackRef);
+  const portalClasses = usePortalModeClasses(trackRef, { resetVisualContext: true });
 
   return (
     <>

--- a/src/annotation-context/annotation/open-annotation.tsx
+++ b/src/annotation-context/annotation/open-annotation.tsx
@@ -5,6 +5,7 @@ import React, { useRef } from 'react';
 import { Portal } from '@cloudscape-design/component-toolkit/internal';
 
 import { HotspotProps } from '../../hotspot/interfaces';
+import { usePortalModeClasses } from '../../internal/hooks/use-portal-mode-classes';
 import { AnnotationContextProps } from '../interfaces';
 import { AnnotationPopover } from './annotation-popover';
 import AnnotationTrigger from './annotation-trigger';
@@ -61,6 +62,7 @@ export function OpenAnnotation({
   i18nStrings,
 }: AnnotationProps) {
   const trackRef = useRef<HTMLButtonElement>(null);
+  const portalClasses = usePortalModeClasses(trackRef);
 
   return (
     <>
@@ -73,24 +75,26 @@ export function OpenAnnotation({
         taskLocalStepIndex={taskLocalStepIndex}
       />
       <Portal>
-        <AnnotationPopover
-          trackRef={trackRef}
-          previousButtonEnabled={previousButtonEnabled}
-          showPreviousButton={showPreviousButton}
-          showFinishButton={showFinishButton}
-          totalLocalSteps={totalLocalSteps}
-          i18nStrings={i18nStrings}
-          nextButtonEnabled={nextButtonEnabled}
-          onDismiss={onDismiss}
-          onFinish={onFinish}
-          onNextButtonClick={onNextButtonClick}
-          onPreviousButtonClick={onPreviousButtonClick}
-          taskLocalStepIndex={taskLocalStepIndex}
-          direction={direction}
-          title={title}
-          content={content}
-          alert={alert}
-        />
+        <span className={portalClasses}>
+          <AnnotationPopover
+            trackRef={trackRef}
+            previousButtonEnabled={previousButtonEnabled}
+            showPreviousButton={showPreviousButton}
+            showFinishButton={showFinishButton}
+            totalLocalSteps={totalLocalSteps}
+            i18nStrings={i18nStrings}
+            nextButtonEnabled={nextButtonEnabled}
+            onDismiss={onDismiss}
+            onFinish={onFinish}
+            onNextButtonClick={onNextButtonClick}
+            onPreviousButtonClick={onPreviousButtonClick}
+            taskLocalStepIndex={taskLocalStepIndex}
+            direction={direction}
+            title={title}
+            content={content}
+            alert={alert}
+          />
+        </span>
       </Portal>
     </>
   );

--- a/src/drawer/__tests__/drawer-position-and-placement.test.tsx
+++ b/src/drawer/__tests__/drawer-position-and-placement.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
@@ -99,6 +99,39 @@ describe('position=fixed', () => {
       <Drawer position="fixed" placement="start" offset={{ start: 8, top: 4, bottom: 12 }} />
     );
     expect(el).toHaveStyle({ insetInlineStart: '8px', insetBlockStart: '4px', insetBlockEnd: '12px' });
+  });
+
+  test('propagates one-theme class to the fixed drawer when one theme is active', () => {
+    const themeRoot = document.createElement('div');
+    themeRoot.className = 'awsui-one-theme';
+    document.body.appendChild(themeRoot);
+
+    try {
+      const el = getDrawerElement(<Drawer position="fixed" />);
+      expect(el).toHaveClass('awsui-one-theme');
+    } finally {
+      themeRoot.remove();
+    }
+  });
+
+  test('propagates compact mode classes to the fixed drawer from the source tree', async () => {
+    render(
+      <div className="awsui-polaris-compact-mode">
+        <Drawer position="fixed" />
+      </div>
+    );
+
+    await waitFor(() => {
+      expect(createWrapper().findDrawer()!.findByClassName(drawerStyles.drawer)!.getElement()).toHaveClass(
+        'awsui-polaris-compact-mode awsui-compact-mode'
+      );
+    });
+  });
+
+  test('does not stamp one-theme class on the fixed drawer when one theme is inactive', () => {
+    const el = getDrawerElement(<Drawer position="fixed" />);
+
+    expect(el).not.toHaveClass('awsui-one-theme');
   });
 });
 

--- a/src/drawer/__tests__/drawer-position-and-placement.test.tsx
+++ b/src/drawer/__tests__/drawer-position-and-placement.test.tsx
@@ -7,6 +7,7 @@ import { render, waitFor } from '@testing-library/react';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import Drawer from '../../../lib/components/drawer';
+import VisualContext from '../../../lib/components/internal/components/visual-context';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
 import drawerStyles from '../../../lib/components/drawer/styles.css.js';
@@ -125,6 +126,22 @@ describe('position=fixed', () => {
       expect(createWrapper().findDrawer()!.findByClassName(drawerStyles.drawer)!.getElement()).toHaveClass(
         'awsui-polaris-compact-mode awsui-compact-mode'
       );
+    });
+  });
+
+  test('does not propagate visual context to the fixed drawer', async () => {
+    render(
+      <div className="awsui-polaris-dark-mode">
+        <VisualContext contextName="alert">
+          <Drawer position="fixed" />
+        </VisualContext>
+      </div>
+    );
+
+    await waitFor(() => {
+      const el = createWrapper().findDrawer()!.findByClassName(drawerStyles.drawer)!.getElement();
+      expect(el).toHaveClass('awsui-polaris-dark-mode awsui-dark-mode');
+      expect(el).not.toHaveClass('awsui-context-alert');
     });
   });
 

--- a/src/drawer/implementation.tsx
+++ b/src/drawer/implementation.tsx
@@ -65,7 +65,7 @@ export function DrawerImplementation({
   const returnFocusTargetRef = useRef<HTMLElement | null>(null);
 
   const baseProps = getBaseProps(restProps);
-  const portalClasses = usePortalModeClasses(portalModeRef);
+  const portalClasses = usePortalModeClasses(portalModeRef, { resetVisualContext: true });
   const isToolbar = useAppLayoutToolbarDesignEnabled();
   const i18n = useInternalI18n('drawer');
   const positionStyles = getPositionStyles({ position, placement, offset, stickyOffset, zIndex });

--- a/src/drawer/implementation.tsx
+++ b/src/drawer/implementation.tsx
@@ -17,6 +17,7 @@ import { getAllFocusables, isFocusable } from '../internal/components/focus-lock
 import { fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
+import { usePortalModeClasses } from '../internal/hooks/use-portal-mode-classes';
 import { createWidgetizedComponent } from '../internal/widgets';
 import InternalLiveRegion from '../live-region/internal';
 import InternalStatusIndicator from '../status-indicator/internal';
@@ -60,9 +61,11 @@ export function DrawerImplementation({
 }: DrawerInternalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const footerRef = useRef<HTMLDivElement>(null);
+  const portalModeRef = useRef<HTMLSpanElement>(null);
   const returnFocusTargetRef = useRef<HTMLElement | null>(null);
 
   const baseProps = getBaseProps(restProps);
+  const portalClasses = usePortalModeClasses(portalModeRef);
   const isToolbar = useAppLayoutToolbarDesignEnabled();
   const i18n = useInternalI18n('drawer');
   const positionStyles = getPositionStyles({ position, placement, offset, stickyOffset, zIndex });
@@ -84,7 +87,8 @@ export function DrawerImplementation({
       isToolbar && styles['with-toolbar'],
       !!footer && styles['with-footer'],
       closeAction && !hideCloseAction && styles['has-close-action'],
-      positionStyles.className
+      positionStyles.className,
+      position === 'fixed' && portalClasses
     ),
   };
 
@@ -226,7 +230,14 @@ export function DrawerImplementation({
     </div>
   );
 
-  return position === 'fixed' ? <Portal>{drawer}</Portal> : drawer;
+  return position === 'fixed' ? (
+    <>
+      <span hidden={true} ref={portalModeRef} />
+      <Portal>{drawer}</Portal>
+    </>
+  ) : (
+    drawer
+  );
 }
 
 export const createWidgetizedDrawer = createWidgetizedComponent(DrawerImplementation);

--- a/src/internal/components/drag-handle-wrapper/__tests__/portal-overlay.test.tsx
+++ b/src/internal/components/drag-handle-wrapper/__tests__/portal-overlay.test.tsx
@@ -109,3 +109,40 @@ test('resumes position updates when enabled after being disabled', async () => {
     expect(portalOverlay.style.height).toBe('20px');
   });
 });
+
+test('propagates one-theme class to the portal overlay when one theme is active', async () => {
+  const themeRoot = document.createElement('div');
+  themeRoot.className = 'awsui-one-theme';
+  document.body.appendChild(themeRoot);
+  const mockRef = createMockRef();
+
+  try {
+    render(
+      <PortalOverlay track={mockRef} isDisabled={false}>
+        <div id="overlay">Overlay</div>
+      </PortalOverlay>
+    );
+
+    const portalOverlay = document.querySelector<HTMLElement>(`.${styles['portal-overlay']}`)!;
+    await waitFor(() => {
+      expect(portalOverlay).toHaveClass('awsui-one-theme');
+    });
+  } finally {
+    themeRoot.remove();
+  }
+});
+
+test('does not stamp one-theme class on the portal overlay when one theme is inactive', async () => {
+  const mockRef = createMockRef();
+
+  render(
+    <PortalOverlay track={mockRef} isDisabled={false}>
+      <div id="overlay">Overlay</div>
+    </PortalOverlay>
+  );
+
+  const portalOverlay = document.querySelector<HTMLElement>(`.${styles['portal-overlay']}`)!;
+  await waitFor(() => {
+    expect(portalOverlay).not.toHaveClass('awsui-one-theme');
+  });
+});

--- a/src/internal/components/drag-handle-wrapper/portal-overlay.tsx
+++ b/src/internal/components/drag-handle-wrapper/portal-overlay.tsx
@@ -10,6 +10,8 @@ import {
   Portal,
 } from '@cloudscape-design/component-toolkit/internal';
 
+import { usePortalModeClasses } from '../../hooks/use-portal-mode-classes';
+
 import styles from './styles.css.js';
 
 export default function PortalOverlay({
@@ -25,6 +27,7 @@ export default function PortalOverlay({
 }) {
   const ref = useRef<HTMLSpanElement | null>(null);
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const portalClasses = usePortalModeClasses(track);
 
   useLayoutEffect(() => {
     if (track.current) {
@@ -90,7 +93,7 @@ export default function PortalOverlay({
       <span
         ref={ref}
         data-awsui-referrer-id={referrerId}
-        className={clsx(styles['portal-overlay'], isDisabled && styles['portal-overlay-disabled'])}
+        className={clsx(portalClasses, styles['portal-overlay'], isDisabled && styles['portal-overlay-disabled'])}
       >
         <span className={styles['portal-overlay-contents']}>{children}</span>
       </span>

--- a/src/internal/components/sortable-area/__tests__/portal-mode.test.tsx
+++ b/src/internal/components/sortable-area/__tests__/portal-mode.test.tsx
@@ -1,0 +1,142 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import SortableArea, { SortableAreaProps } from '../../../../../lib/components/internal/components/sortable-area';
+import useDragAndDropReorder from '../../../../../lib/components/internal/components/sortable-area/use-drag-and-drop-reorder';
+
+import styles from '../../../../../lib/components/internal/components/sortable-area/styles.css.js';
+
+jest.mock('@dnd-kit/core', () => ({
+  ...jest.requireActual('@dnd-kit/core'),
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DragOverlay: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+jest.mock('@dnd-kit/sortable', () => ({
+  ...jest.requireActual('@dnd-kit/sortable'),
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSortable: () => ({
+    isDragging: false,
+    isSorting: false,
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    attributes: {
+      'aria-describedby': 'drag-handle',
+      'aria-disabled': false,
+    },
+  }),
+}));
+
+jest.mock('../../../../../lib/components/internal/components/sortable-area/use-drag-and-drop-reorder');
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const items: readonly Item[] = [
+  { id: '1', label: 'First' },
+  { id: '2', label: 'Second' },
+];
+const itemDefinition: SortableAreaProps.ItemDefinition<Item> = { id: item => item.id, label: item => item.label };
+const mockedUseDragAndDropReorder = useDragAndDropReorder as jest.MockedFunction<typeof useDragAndDropReorder>;
+
+beforeEach(() => {
+  mockedUseDragAndDropReorder.mockReturnValue({
+    activeItemId: '1',
+    setActiveItemId: jest.fn(),
+    collisionDetection: jest.fn(),
+    coordinateGetter: jest.fn(),
+    handleKeyDown: jest.fn(),
+    sensors: [],
+    isKeyboard: { current: false },
+  });
+});
+
+test('propagates one-theme class to the drag overlay when one theme is active', () => {
+  const themeRoot = document.createElement('div');
+  themeRoot.className = 'awsui-one-theme';
+  document.body.appendChild(themeRoot);
+
+  try {
+    render(
+      <SortableArea
+        items={items}
+        itemDefinition={itemDefinition}
+        onItemsChange={() => {}}
+        renderItem={({ item, className, ref }) => (
+          <div ref={ref} className={className}>
+            {item.label}
+          </div>
+        )}
+        i18nStrings={{}}
+      />
+    );
+
+    expect(document.querySelector(`.${styles['drag-overlay']}`)).toHaveClass('awsui-one-theme');
+  } finally {
+    themeRoot.remove();
+  }
+});
+
+test('does not stamp one-theme class on the drag overlay when one theme is inactive', () => {
+  render(
+    <SortableArea
+      items={items}
+      itemDefinition={itemDefinition}
+      onItemsChange={() => {}}
+      renderItem={({ item, className, ref }) => (
+        <div ref={ref} className={className}>
+          {item.label}
+        </div>
+      )}
+      i18nStrings={{}}
+    />
+  );
+
+  expect(document.querySelector(`.${styles['drag-overlay']}`)).not.toHaveClass('awsui-one-theme');
+});
+
+test('does not introduce invalid tbody children while resolving portal classes', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  mockedUseDragAndDropReorder.mockReturnValue({
+    activeItemId: null,
+    setActiveItemId: jest.fn(),
+    collisionDetection: jest.fn(),
+    coordinateGetter: jest.fn(),
+    handleKeyDown: jest.fn(),
+    sensors: [],
+    isKeyboard: { current: false },
+  });
+
+  try {
+    const { container } = render(
+      <table>
+        <tbody>
+          <SortableArea
+            items={items}
+            itemDefinition={itemDefinition}
+            onItemsChange={() => {}}
+            renderItem={({ item, className, ref, style }) => (
+              <tr ref={ref as React.Ref<HTMLTableRowElement>} className={className} style={style}>
+                <td>{item.label}</td>
+              </tr>
+            )}
+            i18nStrings={{}}
+          />
+        </tbody>
+      </table>
+    );
+
+    expect(container.querySelector('tbody > span, tbody > template')).toBeNull();
+    expect(errorSpy.mock.calls.some(call => String(call[0]).includes('validateDOMNesting'))).toBe(false);
+  } finally {
+    errorSpy.mockRestore();
+  }
+});

--- a/src/internal/components/sortable-area/index.tsx
+++ b/src/internal/components/sortable-area/index.tsx
@@ -10,6 +10,7 @@ import clsx from 'clsx';
 import { Portal } from '@cloudscape-design/component-toolkit/internal';
 
 import { fireNonCancelableEvent } from '../../events';
+import { usePortalModeClasses } from '../../hooks/use-portal-mode-classes';
 import { joinStrings } from '../../utils/strings';
 import { SortableAreaProps } from './interfaces';
 import { EventName } from './keyboard-sensor/utilities/events';
@@ -37,6 +38,8 @@ export default function SortableArea<Item>({
   const isDragging = activeItemId !== null;
   const announcements = useLiveAnnouncements({ items, itemDefinition, isDragging, ...i18nStrings });
   const portalContainer = usePortalContainer();
+  const portalModeRef = useRef<HTMLElement>(null);
+  const portalClasses = usePortalModeClasses(portalModeRef);
   return (
     <DndContext
       sensors={sensors}
@@ -67,7 +70,7 @@ export default function SortableArea<Item>({
         items={items.map(item => itemDefinition.id(item))}
         strategy={verticalListSortingStrategy}
       >
-        {items.map(item => (
+        {items.map((item, index) => (
           <DraggableItem
             key={itemDefinition.id(item)}
             item={item}
@@ -76,6 +79,7 @@ export default function SortableArea<Item>({
             renderItem={renderItem}
             onKeyDown={handleKeyDown}
             dragHandleAriaLabel={i18nStrings?.dragHandleAriaLabel}
+            portalModeRef={index === 0 ? portalModeRef : undefined}
           />
         ))}
       </SortableContext>
@@ -84,7 +88,11 @@ export default function SortableArea<Item>({
         {/* Make sure that the drag overlay is above the modal  by assigning the z-index as inline style
             so that it prevails over dnd-kit's inline z-index of 999 */}
         <DragOverlay
-          className={clsx(styles['drag-overlay'], styles[`drag-overlay-${getBorderRadiusVariant(itemDefinition)}`])}
+          className={clsx(
+            portalClasses,
+            styles['drag-overlay'],
+            styles[`drag-overlay-${getBorderRadiusVariant(itemDefinition)}`]
+          )}
           dropAnimation={null}
           style={{ zIndex: 5000 }}
           transition={isKeyboard.current ? 'transform 250ms' : ''}
@@ -133,6 +141,7 @@ function DraggableItem<Item>({
   showDirectionButtons,
   onKeyDown,
   renderItem,
+  portalModeRef,
 }: {
   item: Item;
   itemDefinition: SortableAreaProps.ItemDefinition<Item>;
@@ -140,6 +149,7 @@ function DraggableItem<Item>({
   showDirectionButtons: boolean;
   onKeyDown: (event: React.KeyboardEvent) => void;
   renderItem: (props: SortableAreaProps.RenderItemProps<Item>) => React.ReactNode;
+  portalModeRef?: React.MutableRefObject<HTMLElement | null>;
 }) {
   const id = itemDefinition.id(item);
   const { isDragging, isSorting, listeners, setNodeRef, transform, attributes } = useSortable({
@@ -164,12 +174,18 @@ function DraggableItem<Item>({
     isSorting && styles.sorting
   );
   const dragHandleRef = useRef<HTMLElement>(null);
+  const setItemRef = (element: HTMLElement | null) => {
+    setNodeRef(element);
+    if (portalModeRef) {
+      portalModeRef.current = element;
+    }
+  };
   return (
     <>
       {renderItem({
         item,
         id,
-        ref: setNodeRef,
+        ref: setItemRef,
         style,
         className,
         isDropPlaceholder: isDragging,

--- a/src/internal/components/sortable-area/index.tsx
+++ b/src/internal/components/sortable-area/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { DndContext, DragOverlay } from '@dnd-kit/core';
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -79,6 +79,7 @@ export default function SortableArea<Item>({
             renderItem={renderItem}
             onKeyDown={handleKeyDown}
             dragHandleAriaLabel={i18nStrings?.dragHandleAriaLabel}
+            // All items in one sortable list share the same visual context, so the first item is enough as the anchor.
             portalModeRef={index === 0 ? portalModeRef : undefined}
           />
         ))}
@@ -174,12 +175,15 @@ function DraggableItem<Item>({
     isSorting && styles.sorting
   );
   const dragHandleRef = useRef<HTMLElement>(null);
-  const setItemRef = (element: HTMLElement | null) => {
-    setNodeRef(element);
-    if (portalModeRef) {
-      portalModeRef.current = element;
-    }
-  };
+  const setItemRef = useCallback(
+    (element: HTMLElement | null) => {
+      setNodeRef(element);
+      if (portalModeRef) {
+        portalModeRef.current = element;
+      }
+    },
+    [setNodeRef, portalModeRef]
+  );
   return (
     <>
       {renderItem({

--- a/src/internal/components/tooltip/__tests__/tooltip.test.tsx
+++ b/src/internal/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 
 import Tooltip, { TooltipProps } from '../../../../../lib/components/internal/components/tooltip';
 import StatusIndicator from '../../../../../lib/components/status-indicator';
@@ -98,5 +98,55 @@ describe('Tooltip', () => {
     });
     expect(keydownEvent.stopPropagation).toHaveBeenCalled();
     expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('propagates one-theme class to the portaled tooltip when one theme is active', () => {
+    const themeRoot = document.createElement('div');
+    themeRoot.className = 'awsui-one-theme';
+    document.body.appendChild(themeRoot);
+    const trackRef = React.createRef<HTMLDivElement>();
+
+    try {
+      render(
+        <>
+          <div ref={trackRef} />
+          <Tooltip trackRef={trackRef} value="Value" onDismiss={() => {}} />
+        </>
+      );
+
+      expect(createWrapper().findByClassName(tooltipStyles.root)!.getElement()).toHaveClass('awsui-one-theme');
+    } finally {
+      themeRoot.remove();
+    }
+  });
+
+  it('propagates dark mode classes to the portaled tooltip from the tracked element', async () => {
+    const trackRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <div className="awsui-polaris-dark-mode">
+        <div ref={trackRef} />
+        <Tooltip trackRef={trackRef} value="Value" onDismiss={() => {}} />
+      </div>
+    );
+
+    await waitFor(() => {
+      expect(createWrapper().findByClassName(tooltipStyles.root)!.getElement()).toHaveClass(
+        'awsui-polaris-dark-mode awsui-dark-mode'
+      );
+    });
+  });
+
+  it('does not stamp one-theme class on the portaled tooltip when one theme is inactive', () => {
+    const trackRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <>
+        <div ref={trackRef} />
+        <Tooltip trackRef={trackRef} value="Value" onDismiss={() => {}} />
+      </>
+    );
+
+    expect(createWrapper().findByClassName(tooltipStyles.root)!.getElement()).not.toHaveClass('awsui-one-theme');
   });
 });

--- a/src/internal/components/tooltip/__tests__/tooltip.test.tsx
+++ b/src/internal/components/tooltip/__tests__/tooltip.test.tsx
@@ -137,6 +137,23 @@ describe('Tooltip', () => {
     });
   });
 
+  it('renders with an SVG tracked element without throwing', async () => {
+    const trackRef = React.createRef<SVGSVGElement>();
+
+    expect(() =>
+      render(
+        <>
+          <svg ref={trackRef} />
+          <Tooltip trackRef={trackRef} value="Value" onDismiss={() => {}} />
+        </>
+      )
+    ).not.toThrow();
+
+    await waitFor(() => {
+      expect(createWrapper().findByClassName(tooltipStyles.root)).not.toBeNull();
+    });
+  });
+
   it('does not stamp one-theme class on the portaled tooltip when one theme is inactive', () => {
     const trackRef = React.createRef<HTMLDivElement>();
 

--- a/src/internal/components/tooltip/index.tsx
+++ b/src/internal/components/tooltip/index.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect } from 'react';
+import clsx from 'clsx';
 
 import { Portal } from '@cloudscape-design/component-toolkit/internal';
 
@@ -8,6 +9,7 @@ import PopoverArrow from '../../../popover/arrow';
 import PopoverBody from '../../../popover/body';
 import PopoverContainer from '../../../popover/container';
 import { PopoverProps } from '../../../popover/interfaces';
+import { usePortalModeClasses } from '../../hooks/use-portal-mode-classes';
 import { Transition } from '../transition';
 
 import testUtilsStyles from '../../../tooltip/test-classes/styles.css.js';
@@ -41,6 +43,8 @@ export default function Tooltip({
   hideOnOverscroll,
   onDismiss,
 }: TooltipProps) {
+  const portalClasses = usePortalModeClasses(trackRef as React.RefObject<HTMLElement>);
+
   if (!trackKey && (typeof value === 'string' || typeof value === 'number')) {
     trackKey = value;
   }
@@ -71,7 +75,11 @@ export default function Tooltip({
 
   return (
     <Portal>
-      <div className={`${styles.root} ${testUtilsStyles.root}`} {...contentAttributes} data-testid={trackKey}>
+      <div
+        className={clsx(portalClasses, styles.root, testUtilsStyles.root)}
+        {...contentAttributes}
+        data-testid={trackKey}
+      >
         <Transition in={true}>
           {() => (
             <PopoverContainer

--- a/src/internal/components/tooltip/index.tsx
+++ b/src/internal/components/tooltip/index.tsx
@@ -43,7 +43,7 @@ export default function Tooltip({
   hideOnOverscroll,
   onDismiss,
 }: TooltipProps) {
-  const portalClasses = usePortalModeClasses(trackRef as React.RefObject<HTMLElement>);
+  const portalClasses = usePortalModeClasses(trackRef);
 
   if (!trackKey && (typeof value === 'string' || typeof value === 'number')) {
     trackKey = value;

--- a/src/internal/components/visual-context/__tests__/index.test.tsx
+++ b/src/internal/components/visual-context/__tests__/index.test.tsx
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useRef } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import VisualContext, { useVisualContext } from '../../../../../lib/components/internal/components/visual-context';
+
+function ContextProbe({ element }: { element: 'html' | 'svg' | 'none' }) {
+  const ref = useRef<Element | null>(null);
+  const value = useVisualContext(ref);
+
+  return (
+    <>
+      {element === 'html' && <div ref={node => void (ref.current = node)} />}
+      {element === 'svg' && <svg ref={node => void (ref.current = node)} />}
+      {element === 'none' && <div />}
+      <div data-testid="context">{value}</div>
+    </>
+  );
+}
+
+describe('useVisualContext', () => {
+  test('resolves context from an HTML start node', async () => {
+    render(
+      <VisualContext contextName="alert">
+        <ContextProbe element="html" />
+      </VisualContext>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('context')).toHaveTextContent('alert');
+    });
+  });
+
+  test('resolves context from an SVG start node without throwing', async () => {
+    expect(() =>
+      render(
+        <VisualContext contextName="alert">
+          <ContextProbe element="svg" />
+        </VisualContext>
+      )
+    ).not.toThrow();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('context')).toHaveTextContent('alert');
+    });
+  });
+
+  test('returns an empty string when no visual context ancestor exists', async () => {
+    render(<ContextProbe element="none" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('context')).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/src/internal/components/visual-context/index.tsx
+++ b/src/internal/components/visual-context/index.tsx
@@ -13,13 +13,21 @@ interface VisualContextProps {
 
 const contextMatch = /awsui-context-([\w-]+)/;
 
-export function useVisualContext(elementRef: React.RefObject<HTMLElement | null>) {
+function getClassName(element: Element): string {
+  return element.getAttribute('class') ?? '';
+}
+
+export function useVisualContext(elementRef: React.RefObject<Element | null>) {
   const [value, setValue] = useState('');
 
   useLayoutEffect(() => {
     if (elementRef.current) {
-      const contextParent = findUpUntil(elementRef.current, node => !!node.className.match(contextMatch));
-      setValue(contextParent?.className.match(contextMatch)![1] ?? '');
+      const contextParent = findUpUntil(
+        // @ts-expect-error The implementation only reads parentElement from the start node before walking HTML ancestors.
+        elementRef.current,
+        node => !!getClassName(node).match(contextMatch)
+      );
+      setValue(contextParent ? (getClassName(contextParent).match(contextMatch)?.[1] ?? '') : '');
     }
   }, [elementRef]);
 

--- a/src/internal/components/visual-context/index.tsx
+++ b/src/internal/components/visual-context/index.tsx
@@ -13,7 +13,7 @@ interface VisualContextProps {
 
 const contextMatch = /awsui-context-([\w-]+)/;
 
-export function useVisualContext(elementRef: React.RefObject<HTMLElement>) {
+export function useVisualContext(elementRef: React.RefObject<HTMLElement | null>) {
   const [value, setValue] = useState('');
 
   useLayoutEffect(() => {

--- a/src/internal/do-not-use/feature-prompt/__tests__/feature-prompt.test.tsx
+++ b/src/internal/do-not-use/feature-prompt/__tests__/feature-prompt.test.tsx
@@ -169,4 +169,27 @@ describe('FeaturePrompt', () => {
     expect(onDismissMock).toHaveBeenCalledWith(expect.objectContaining({ detail: { method: 'click-outside' } }));
     expect(wrapper.findContent()).toBeFalsy();
   });
+
+  test('should propagate one-theme class to the portaled feature prompt when one theme is active', () => {
+    const themeRoot = document.createElement('div');
+    themeRoot.className = 'awsui-one-theme';
+    document.body.appendChild(themeRoot);
+
+    try {
+      const { getByTestId, wrapper } = renderComponent(<TestComponent />);
+      getByTestId('trigger-button').click();
+
+      expect(wrapper.findContent()!.getElement().closest('.awsui-one-theme')).not.toBeNull();
+    } finally {
+      themeRoot.remove();
+    }
+  });
+
+  test('should not stamp one-theme class on the portaled feature prompt when one theme is inactive', () => {
+    const { getByTestId, wrapper } = renderComponent(<TestComponent />);
+
+    getByTestId('trigger-button').click();
+
+    expect(wrapper.findContent()!.getElement().closest('.awsui-one-theme')).toBeNull();
+  });
 });

--- a/src/internal/do-not-use/feature-prompt/__tests__/feature-prompt.test.tsx
+++ b/src/internal/do-not-use/feature-prompt/__tests__/feature-prompt.test.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useRef } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
+import VisualContext from '../../../../../lib/components/internal/components/visual-context';
 import FeaturePrompt, { FeaturePromptProps } from '../../../../../lib/components/internal/do-not-use/feature-prompt';
 import FeaturePromptWrapper from '../../../../../lib/components/test-utils/dom/internal/feature-prompt';
 
@@ -191,5 +192,20 @@ describe('FeaturePrompt', () => {
     getByTestId('trigger-button').click();
 
     expect(wrapper.findContent()!.getElement().closest('.awsui-one-theme')).toBeNull();
+  });
+
+  test('should not propagate visual context to the portaled feature prompt', () => {
+    const { getByTestId, wrapper } = renderComponent(
+      <div className="awsui-polaris-dark-mode">
+        <VisualContext contextName="alert">
+          <TestComponent />
+        </VisualContext>
+      </div>
+    );
+
+    getByTestId('trigger-button').click();
+
+    expect(wrapper.findContent()!.getElement().closest('.awsui-polaris-dark-mode')).not.toBeNull();
+    expect(wrapper.findContent()!.getElement().closest('.awsui-context-alert')).toBeNull();
   });
 });

--- a/src/internal/do-not-use/feature-prompt/internal.tsx
+++ b/src/internal/do-not-use/feature-prompt/internal.tsx
@@ -45,7 +45,7 @@ function InternalFeaturePrompt(
   const popoverBodyRef = useRef<HTMLDivElement | null>(null);
   const rootRef = useRef<HTMLSpanElement | null>(null);
   const mergedRef = useMergeRefs(rootRef, __internalRootRef);
-  const portalClasses = usePortalModeClasses(rootRef);
+  const portalClasses = usePortalModeClasses(rootRef, { resetVisualContext: true });
 
   useImperativeHandle(ref, () => ({
     dismiss: () => {

--- a/src/internal/do-not-use/feature-prompt/internal.tsx
+++ b/src/internal/do-not-use/feature-prompt/internal.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useImperativeHandle, useRef, useState } from 'react';
 
-import { Portal } from '@cloudscape-design/component-toolkit/internal';
+import { Portal, useMergeRefs } from '@cloudscape-design/component-toolkit/internal';
 
 import { SomeRequired } from '../../../internal/types';
 import Arrow from '../../../popover/arrow';
@@ -13,6 +13,7 @@ import { getBaseProps } from '../../base-component';
 import ResetContextsForModal from '../../context/reset-contexts-for-modal';
 import { fireNonCancelableEvent } from '../../events';
 import { InternalBaseComponentProps } from '../../hooks/use-base-component';
+import { usePortalModeClasses } from '../../hooks/use-portal-mode-classes';
 import { nodeBelongs } from '../../utils/node-belongs';
 import { FeaturePromptProps } from './interfaces';
 
@@ -42,6 +43,9 @@ function InternalFeaturePrompt(
   const [show, setShow] = useState(false);
 
   const popoverBodyRef = useRef<HTMLDivElement | null>(null);
+  const rootRef = useRef<HTMLSpanElement | null>(null);
+  const mergedRef = useMergeRefs(rootRef, __internalRootRef);
+  const portalClasses = usePortalModeClasses(rootRef);
 
   useImperativeHandle(ref, () => ({
     dismiss: () => {
@@ -86,43 +90,45 @@ function InternalFeaturePrompt(
   }, [show, onDismiss]);
 
   return (
-    <span {...baseProps} className={styles.root} ref={__internalRootRef}>
+    <span {...baseProps} className={styles.root} ref={mergedRef}>
       {show && (
         <Portal>
-          <ResetContextsForModal>
-            <PopoverContainer
-              size={size}
-              fixedWidth={false}
-              position={position}
-              getTrack={getTrack}
-              trackKey={trackKey}
-              variant="annotation"
-              arrow={position => <Arrow position={position} variant="info" />}
-              zIndex={7000}
-              renderWithPortal={true}
-            >
-              <PopoverBody
-                ref={popoverBodyRef}
-                dismissButton={true}
-                dismissAriaLabel={i18nStrings?.dismissAriaLabel}
-                header={header}
-                onDismiss={method => {
-                  setShow(false);
-                  fireNonCancelableEvent(onDismiss, { method });
-                }}
-                onBlur={event => {
-                  if (event.relatedTarget && !event.currentTarget.contains(event.relatedTarget)) {
-                    setShow(false);
-                    fireNonCancelableEvent(onDismiss, { method: 'blur' });
-                  }
-                }}
-                variant="feature-prompt"
-                overflowVisible="content"
+          <span className={portalClasses}>
+            <ResetContextsForModal>
+              <PopoverContainer
+                size={size}
+                fixedWidth={false}
+                position={position}
+                getTrack={getTrack}
+                trackKey={trackKey}
+                variant="annotation"
+                arrow={position => <Arrow position={position} variant="info" />}
+                zIndex={7000}
+                renderWithPortal={true}
               >
-                {content}
-              </PopoverBody>
-            </PopoverContainer>
-          </ResetContextsForModal>
+                <PopoverBody
+                  ref={popoverBodyRef}
+                  dismissButton={true}
+                  dismissAriaLabel={i18nStrings?.dismissAriaLabel}
+                  header={header}
+                  onDismiss={method => {
+                    setShow(false);
+                    fireNonCancelableEvent(onDismiss, { method });
+                  }}
+                  onBlur={event => {
+                    if (event.relatedTarget && !event.currentTarget.contains(event.relatedTarget)) {
+                      setShow(false);
+                      fireNonCancelableEvent(onDismiss, { method: 'blur' });
+                    }
+                  }}
+                  variant="feature-prompt"
+                  overflowVisible="content"
+                >
+                  {content}
+                </PopoverBody>
+              </PopoverContainer>
+            </ResetContextsForModal>
+          </span>
         </Portal>
       )}
     </span>

--- a/src/internal/hooks/use-portal-mode-classes/index.ts
+++ b/src/internal/hooks/use-portal-mode-classes/index.ts
@@ -9,9 +9,12 @@ import { useVisualContext } from '../../components/visual-context';
 import { ALWAYS_VISUAL_REFRESH } from '../../environment';
 import { useOneTheme, useVisualRefresh } from '../use-visual-mode';
 
-export function usePortalModeClasses(ref: React.RefObject<HTMLElement>, options?: { resetVisualContext?: boolean }) {
-  const colorMode = useCurrentMode(ref);
-  const densityMode = useDensityMode(ref);
+export function usePortalModeClasses(
+  ref: React.RefObject<HTMLElement | null>,
+  options?: { resetVisualContext?: boolean }
+) {
+  const colorMode = useCurrentMode(ref as React.RefObject<HTMLElement>);
+  const densityMode = useDensityMode(ref as React.RefObject<HTMLElement>);
   const context = useVisualContext(ref);
   const oneTheme = useOneTheme();
   const visualRefreshWithClass = useVisualRefresh() && !ALWAYS_VISUAL_REFRESH && !oneTheme;

--- a/src/internal/hooks/use-portal-mode-classes/index.ts
+++ b/src/internal/hooks/use-portal-mode-classes/index.ts
@@ -10,10 +10,12 @@ import { ALWAYS_VISUAL_REFRESH } from '../../environment';
 import { useOneTheme, useVisualRefresh } from '../use-visual-mode';
 
 export function usePortalModeClasses(
-  ref: React.RefObject<HTMLElement | null>,
+  ref: React.RefObject<HTMLElement | SVGElement | null>,
   options?: { resetVisualContext?: boolean }
 ) {
+  // `useCurrentMode` reads `classList`, which is available on SVG elements.
   const colorMode = useCurrentMode(ref as React.RefObject<HTMLElement>);
+  // `useDensityMode` also reads `classList`, which is available on SVG elements.
   const densityMode = useDensityMode(ref as React.RefObject<HTMLElement>);
   const context = useVisualContext(ref);
   const oneTheme = useOneTheme();

--- a/src/modal/__tests__/modal.test.tsx
+++ b/src/modal/__tests__/modal.test.tsx
@@ -10,6 +10,7 @@ import DatePicker from '../../../lib/components/date-picker';
 import DateRangePicker from '../../../lib/components/date-range-picker';
 import FormField from '../../../lib/components/form-field';
 import Input from '../../../lib/components/input';
+import VisualContext from '../../../lib/components/internal/components/visual-context';
 import Modal, { ModalProps } from '../../../lib/components/modal';
 import Multiselect from '../../../lib/components/multiselect';
 import Popover from '../../../lib/components/popover';
@@ -127,6 +128,30 @@ describe('Modal component', () => {
           expect(createWrapper(modalRoot).findModal()!.getElement()).toHaveClass(
             'awsui-polaris-dark-mode awsui-dark-mode'
           );
+        });
+      } finally {
+        modalRoot.remove();
+      }
+    });
+
+    it('does not propagate visual context to the portaled root', async () => {
+      const modalRoot = document.createElement('div');
+      document.body.appendChild(modalRoot);
+
+      try {
+        render(
+          <div className="awsui-polaris-dark-mode">
+            <VisualContext contextName="alert">
+              <Modal visible={true} modalRoot={modalRoot} />
+            </VisualContext>
+          </div>
+        );
+
+        await waitFor(() => {
+          expect(createWrapper(modalRoot).findModal()!.getElement()).toHaveClass(
+            'awsui-polaris-dark-mode awsui-dark-mode'
+          );
+          expect(createWrapper(modalRoot).findModal()!.getElement()).not.toHaveClass('awsui-context-alert');
         });
       } finally {
         modalRoot.remove();

--- a/src/modal/__tests__/modal.test.tsx
+++ b/src/modal/__tests__/modal.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { act, fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 
 import Autosuggest from '../../../lib/components/autosuggest';
 import Button from '../../../lib/components/button/index.js';
@@ -95,6 +95,54 @@ describe('Modal component', () => {
       const wrapper = renderModal({ onDismiss: onDismissSpy });
       wrapper.findDismissButton().click();
       expect(onDismissSpy).toHaveBeenCalled();
+    });
+
+    it('propagates one-theme class to the portaled root when one theme is active', () => {
+      const themeRoot = document.createElement('div');
+      themeRoot.className = 'awsui-one-theme';
+      document.body.appendChild(themeRoot);
+      const modalRoot = document.createElement('div');
+      document.body.appendChild(modalRoot);
+
+      try {
+        render(<Modal visible={true} modalRoot={modalRoot} />);
+        expect(createWrapper(modalRoot).findModal()!.getElement()).toHaveClass('awsui-one-theme');
+      } finally {
+        modalRoot.remove();
+        themeRoot.remove();
+      }
+    });
+
+    it('propagates dark mode classes to the portaled root from the source tree', async () => {
+      const modalRoot = document.createElement('div');
+      document.body.appendChild(modalRoot);
+
+      try {
+        render(
+          <div className="awsui-polaris-dark-mode">
+            <Modal visible={true} modalRoot={modalRoot} />
+          </div>
+        );
+        await waitFor(() => {
+          expect(createWrapper(modalRoot).findModal()!.getElement()).toHaveClass(
+            'awsui-polaris-dark-mode awsui-dark-mode'
+          );
+        });
+      } finally {
+        modalRoot.remove();
+      }
+    });
+
+    it('does not stamp one-theme class on the portaled root when one theme is inactive', () => {
+      const modalRoot = document.createElement('div');
+      document.body.appendChild(modalRoot);
+
+      try {
+        render(<Modal visible={true} modalRoot={modalRoot} />);
+        expect(createWrapper(modalRoot).findModal()!.getElement()).not.toHaveClass('awsui-one-theme');
+      } finally {
+        modalRoot.remove();
+      }
     });
   });
 

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -80,7 +80,7 @@ type InternalModalProps = SomeRequired<ModalProps, 'size'> &
 
 export default function InternalModal({ modalRoot, getModalRoot, removeModalRoot, ...rest }: InternalModalProps) {
   const portalModeRef = useRef<HTMLSpanElement>(null);
-  const portalClasses = usePortalModeClasses(portalModeRef);
+  const portalClasses = usePortalModeClasses(portalModeRef, { resetVisualContext: true });
 
   return (
     <>

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -27,6 +27,7 @@ import { fireNonCancelableEvent } from '../internal/events';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useIntersectionObserver } from '../internal/hooks/use-intersection-observer';
+import { usePortalModeClasses } from '../internal/hooks/use-portal-mode-classes';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { KeyCode } from '../internal/keycode';
 import { SomeRequired } from '../internal/types';
@@ -78,14 +79,22 @@ type InternalModalProps = SomeRequired<ModalProps, 'size'> &
   };
 
 export default function InternalModal({ modalRoot, getModalRoot, removeModalRoot, ...rest }: InternalModalProps) {
+  const portalModeRef = useRef<HTMLSpanElement>(null);
+  const portalClasses = usePortalModeClasses(portalModeRef);
+
   return (
-    <Portal container={modalRoot} getContainer={getModalRoot} removeContainer={removeModalRoot}>
-      <PortaledModal {...rest} />
-    </Portal>
+    <>
+      <span hidden={true} ref={portalModeRef} />
+      <Portal container={modalRoot} getContainer={getModalRoot} removeContainer={removeModalRoot}>
+        <PortaledModal {...rest} portalClasses={portalClasses} />
+      </Portal>
+    </>
   );
 }
 
-type PortaledModalProps = Omit<InternalModalProps, 'modalRoot' | 'getModalRoot' | 'removeModalRoot'>;
+type PortaledModalProps = Omit<InternalModalProps, 'modalRoot' | 'getModalRoot' | 'removeModalRoot'> & {
+  portalClasses: string;
+};
 
 // Separate component to prevent the Portal from getting in the way of refs, as it needs extra cycles to render the inner components.
 // useContainerQuery needs its targeted element to exist on the first render in order to work properly.
@@ -108,6 +117,7 @@ function PortaledModal({
   __subStepRef,
   __subStepFunnelProps,
   referrerId,
+  portalClasses,
   ...rest
 }: PortaledModalProps) {
   const instanceUniqueId = useUniqueId();
@@ -243,6 +253,7 @@ function PortaledModal({
             {...__funnelProps}
             {...__funnelStepProps}
             className={clsx(
+              portalClasses,
               styles.root,
               { [styles.hidden]: !visible },
               baseProps.className,

--- a/src/tooltip/__tests__/tooltip.test.tsx
+++ b/src/tooltip/__tests__/tooltip.test.tsx
@@ -110,6 +110,39 @@ describe('Tooltip', () => {
     expect(wrapper).not.toBeNull();
   });
 
+  it('propagates one-theme class to the portaled tooltip when one theme is active', () => {
+    const themeRoot = document.createElement('div');
+    themeRoot.className = 'awsui-one-theme';
+    document.body.appendChild(themeRoot);
+    const trackRef = React.createRef<HTMLDivElement>();
+
+    try {
+      render(
+        <>
+          <div ref={trackRef} />
+          <Tooltip content="Value" getTrack={() => trackRef.current} />
+        </>
+      );
+
+      expect(createWrapper().findTooltip()!.getElement()).toHaveClass('awsui-one-theme');
+    } finally {
+      themeRoot.remove();
+    }
+  });
+
+  it('does not stamp one-theme class on the portaled tooltip when one theme is inactive', () => {
+    const trackRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <>
+        <div ref={trackRef} />
+        <Tooltip content="Value" getTrack={() => trackRef.current} />
+      </>
+    );
+
+    expect(createWrapper().findTooltip()!.getElement()).not.toHaveClass('awsui-one-theme');
+  });
+
   it('updates tracked element when getTrack changes', () => {
     const element1 = document.createElement('div');
     const element2 = document.createElement('div');

--- a/src/tooltip/internal.tsx
+++ b/src/tooltip/internal.tsx
@@ -9,6 +9,7 @@ import { getBaseProps } from '../internal/base-component';
 import { Transition } from '../internal/components/transition';
 import { fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import { usePortalModeClasses } from '../internal/hooks/use-portal-mode-classes';
 import PopoverArrow from '../popover/arrow';
 import PopoverBody from '../popover/body';
 import PopoverContainer from '../popover/container';
@@ -36,6 +37,7 @@ export default function InternalTooltip({
 }: InternalTooltipComponentProps) {
   const baseProps = getBaseProps(restProps);
   const trackRef = React.useRef<HTMLElement | SVGElement | null>(null);
+  const portalClasses = usePortalModeClasses(trackRef as React.RefObject<HTMLElement>);
 
   // Update the ref with the current tracked element
   React.useEffect(() => {
@@ -71,7 +73,7 @@ export default function InternalTooltip({
     <Portal>
       <div
         {...baseProps}
-        className={clsx(testUtilStyles.root, styles.root, baseProps.className)}
+        className={clsx(portalClasses, testUtilStyles.root, styles.root, baseProps.className)}
         ref={__internalRootRef}
         data-awsui-referrer-id={referrerId}
         role="tooltip"

--- a/src/tooltip/internal.tsx
+++ b/src/tooltip/internal.tsx
@@ -37,7 +37,7 @@ export default function InternalTooltip({
 }: InternalTooltipComponentProps) {
   const baseProps = getBaseProps(restProps);
   const trackRef = React.useRef<HTMLElement | SVGElement | null>(null);
-  const portalClasses = usePortalModeClasses(trackRef as React.RefObject<HTMLElement>);
+  const portalClasses = usePortalModeClasses(trackRef);
 
   // Update the ref with the current tracked element
   React.useEffect(() => {


### PR DESCRIPTION
## Description

This draft PR applies `usePortalModeClasses` to the remaining portaled components so portal-mode styling follows the same shared pattern across the codebase.

Some components already preserve portal-mode classes correctly when rendering through portals, while others still rely on component-specific handling. This change aligns those implementations and closes the remaining propagation gaps.

## Changes

- apply `usePortalModeClasses` to remaining portaled components
- replace inconsistent component-level portal-mode handling with the shared hook
- add or update tests covering portal-mode class propagation

## Why

This keeps portal behavior consistent across components and reduces the chance of styling mismatches when content is rendered outside the normal DOM tree.

## Testing

- updated relevant tests for affected portaled components
- verified portal-mode classes propagate as expected in portal-rendered content
