### PR TITLE
fix: Stop importing the generated test-utils barrel from two wrappers

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -217,7 +217,7 @@ export default tsEslint.config(
         'error',
         [
           {
-            pattern: './src/test-utils/dom/index.ts',
+            pattern: './src/test-utils/dom/index.*s',
             message:
               "Do not import from the augmented ElementWrapper barrel '{{ path }}'. Use @cloudscape-design/test-utils-core/dom instead.",
           },

--- a/src/test-utils/dom/button-group/index.ts
+++ b/src/test-utils/dom/button-group/index.ts
@@ -1,11 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, createWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 import ButtonWrapper from '../button/index.js';
 import ButtonDropdownWrapper from '../button-dropdown/index.js';
 import FileInputWrapper from '../file-input/index.js';
-import createWrapper from '../index.js';
 import ToggleButtonWrapper from '../toggle-button/index.js';
 
 import testUtilStyles from '../../../button-group/test-classes/styles.selectors.js';

--- a/src/test-utils/dom/popover/index.ts
+++ b/src/test-utils/dom/popover/index.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, createWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 import ButtonWrapper from '../button';
-import createWrapper from '../index.js';
 
 import styles from '../../../popover/styles.selectors.js';
 


### PR DESCRIPTION
While working on https://github.com/cloudscape-design/components/issues/4948, I noticed that the [ban-files](https://github.com/cloudscape-design/build-tools/blob/4ceb7db047027e1f2713537c957bdbd6a87b1dd9/lib/eslint/ban-files.js) rule defined in the build-tools repo has a bug that's causing it to miss two existing violations in this repo. This PR fixes those violations, before I fix the rule itself.

## The violation

`src/test-utils/dom/index.ts` imports every component wrapper. A wrapper importing it back is therefore circular, which is what `ban-files` is configured to prevent. The two `import createWrapper from '../index.js'` lines removed by this PR should have triggered a rule violation like this:

```
Do not import from the augmented ElementWrapper barrel 'src/test-utils/dom/index.ts'.
Use @cloudscape-design/test-utils-core/dom instead.
```

The reason they didn't trigger it is that they include the `.js` extension, which `ban-files` doesn't expect. The rule only probed extensions appended to the literal path, so it tested `src/test-utils/dom/index.js` and `src/test-utils/dom/index.js.ts` rather than matching the banned `src/test-utils/dom/index.ts`.

## The fix

`@cloudscape-design/test-utils-core` already exports `createWrapper` from both its `/dom` and `/selectors` entry points, and its implementation is the same one the generated barrel copies:

```js
// test-utils-core/dom            // the generated barrel
createWrapper(root = document.body)   wrapper(root: Element = document.body)
```

So swapping the import is behaviour-identical, and the call sites are untouched. Importing from `test-utils-core/dom` also means the selectors converter rewrites the path to `/selectors` for free, so the generated selectors output stops importing its barrel too.

