### PR TITLE
fix: grant pull-requests read to the codecov fork upload wrapper

### DIFF
--- a/.github/workflows/codecov-fork-upload.yml
+++ b/.github/workflows/codecov-fork-upload.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 jobs:
   codecov-fork:


### PR DESCRIPTION
The shared reusable workflow `cloudscape-design/actions/.github/workflows/codecov-fork-upload.yml@main` declares workflow-level `permissions` of `contents: read`, `actions: read` and `pull-requests: read`. The last one is needed by its pull request resolver step, which calls `pulls.list` to resolve the fork pull request from the trusted head SHA.

GitHub requires a called reusable workflow to request a subset of what the caller grants. This wrapper granted only `actions: read` and `contents: read`, leaving `pull-requests` implicitly `none`, so the call was rejected at workflow validation time before any job ran:

```
Invalid workflow file: .github/workflows/codecov-fork-upload.yml#L14
The workflow is not valid. .github/workflows/codecov-fork-upload.yml (Line: 14, Col: 3):
Error calling workflow 'cloudscape-design/actions/.github/workflows/codecov-fork-upload.yml@main'.
The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.
```

This adds the missing scope so the granted permissions are a superset of the requested ones on every scope. The wrapper was authored before `pull-requests: read` was added to the reusable workflow during review, which is how the two drifted apart.

Scope ordering follows the existing `deploy-fork-preview.yml` wrapper in this repo, where read scopes are listed alphabetically.