### PR TITLE
fix: One Theme - Update background color in header context to match l…

### DIFF
--- a/style-dictionary/one-theme/contexts/header.ts
+++ b/style-dictionary/one-theme/contexts/header.ts
@@ -11,7 +11,7 @@ import { tokens as parentShadowsTokens } from '../shadows.js';
 // All values are mode-invariant (single string = same in light and dark).
 
 const colorTokens: StyleDictionary.ColorsDictionary = {
-  colorBackgroundLayoutMain: '{colorNeutral800}',
+  colorBackgroundLayoutMain: '{colorNeutral950}',
 };
 
 const darkColorValues = pickState(parentColorTokens, 'dark');


### PR DESCRIPTION
…anding page header token

### Description

Currently there is a mismatch in landing pages across applications

Related links, issue #, if available: n/a

### How has this been tested?

Manually

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
