### PR TITLE
chore: Replace one-theme’s side navigation icon

### DIFF
--- a/src/app-layout/__tests__/navigation-collapsed.test.tsx
+++ b/src/app-layout/__tests__/navigation-collapsed.test.tsx
@@ -65,13 +65,27 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
       expect(closeButton.querySelector(`.${iconStyles['name-angle-left']}`)).not.toBeNull();
     });
 
-    test.each([true, false])('close button shows side-bar icon in One Theme, navigationOpen=%s', navigationOpen => {
-      (isThemeActive as jest.Mock).mockReturnValue(true);
-      const { wrapper } = renderComponent(
-        <AppLayout navigationCloseBehavior="collapse" navigationOpen={navigationOpen} navigation={<>Nav content</>} />
-      );
-      expect(wrapper.findNavigationClose().findIcon()!.getElement()).toContainHTML(getIconHTML('side-bar'));
-    });
+    test.each([true, false])(
+      'close button shows side-bar icon in One Theme when navigationCloseBehavior=collapse, navigationOpen=%s',
+      navigationOpen => {
+        (isThemeActive as jest.Mock).mockReturnValue(true);
+        const { wrapper } = renderComponent(
+          <AppLayout navigationCloseBehavior="collapse" navigationOpen={navigationOpen} navigation={<>Nav content</>} />
+        );
+        expect(wrapper.findNavigationClose().findIcon()!.getElement()).toContainHTML(getIconHTML('side-bar'));
+      }
+    );
+
+    test.each([true, false])(
+      'close button shows angle-left icon in One Theme when navigationCloseBehavior!=collapse, navigationOpen=%s',
+      navigationOpen => {
+        (isThemeActive as jest.Mock).mockReturnValue(true);
+        const { wrapper } = renderComponent(
+          <AppLayout navigationOpen={navigationOpen} navigation={<>Nav content</>} />
+        );
+        expect(wrapper.findNavigationClose().findIcon()!.getElement()).toContainHTML(getIconHTML('angle-left'));
+      }
+    );
 
     test('close button toggles navigation open and closed when collapsible', () => {
       const { wrapper } = renderComponent(

--- a/src/app-layout/__tests__/navigation-collapsed.test.tsx
+++ b/src/app-layout/__tests__/navigation-collapsed.test.tsx
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { isThemeActive } from '@cloudscape-design/component-toolkit/internal';
+
 import AppLayout from '../../../lib/components/app-layout';
 import customCssProps from '../../../lib/components/internal/generated/custom-css-properties';
+import { getIconHTML } from '../../icon/__tests__/utils';
 import { describeEachAppLayout, renderComponent } from './utils';
 
 import navStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/navigation/styles.css.js';
@@ -14,6 +17,15 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit'),
   useContainerQuery: () => [1300, () => {}],
 }));
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
+  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
+  isThemeActive: jest.fn().mockReturnValue(false),
+}));
+
+afterEach(() => {
+  (isThemeActive as jest.Mock).mockReturnValue(false);
+});
 
 describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
   describe('collapsed rail visibility', () => {
@@ -51,6 +63,14 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
       );
       const closeButton = wrapper.findNavigationClose().getElement();
       expect(closeButton.querySelector(`.${iconStyles['name-angle-left']}`)).not.toBeNull();
+    });
+
+    test.each([true, false])('close button shows side-bar icon in One Theme, navigationOpen=%s', navigationOpen => {
+      (isThemeActive as jest.Mock).mockReturnValue(true);
+      const { wrapper } = renderComponent(
+        <AppLayout navigationCloseBehavior="collapse" navigationOpen={navigationOpen} navigation={<>Nav content</>} />
+      );
+      expect(wrapper.findNavigationClose().findIcon()!.getElement()).toContainHTML(getIconHTML('side-bar'));
     });
 
     test('close button toggles navigation open and closed when collapsible', () => {

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -4,8 +4,10 @@ import React from 'react';
 import clsx from 'clsx';
 
 import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
+import { isThemeActive, Theme } from '@cloudscape-design/component-toolkit/internal';
 
 import { InternalButton } from '../../../button/internal';
+import { IconProps } from '../../../icon/interfaces';
 import { getDrawerStyles } from '../compute-layout';
 import { AppLayoutInternals } from '../interfaces';
 
@@ -55,6 +57,16 @@ export function AppLayoutNavigationImplementation({
     }
   };
 
+  const getNavIconName = (): IconProps.Name => {
+    if (isMobile) {
+      return 'close';
+    }
+    if (isThemeActive(Theme.OneTheme)) {
+      return 'side-bar';
+    }
+    return navigationCollapsed ? 'angle-right' : 'angle-left';
+  };
+
   return (
     <div
       className={clsx(styles['navigation-container'], sharedStyles['with-motion-horizontal'], {
@@ -90,7 +102,7 @@ export function AppLayoutNavigationImplementation({
                 : (ariaLabels?.navigationClose ?? undefined)
             }
             ariaExpanded={navigationCollapsible && !isMobile ? navigationOpen : undefined}
-            iconName={navigationCollapsed ? 'angle-right' : isMobile ? 'close' : 'angle-left'}
+            iconName={getNavIconName()}
             onClick={() => onNavigationToggle(navigationCollapsible ? !navigationOpen : false)}
             variant="icon"
             formAction="none"

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -61,7 +61,7 @@ export function AppLayoutNavigationImplementation({
     if (isMobile) {
       return 'close';
     }
-    if (isThemeActive(Theme.OneTheme)) {
+    if (isThemeActive(Theme.OneTheme) && navigationCollapsible) {
       return 'side-bar';
     }
     return navigationCollapsed ? 'angle-right' : 'angle-left';


### PR DESCRIPTION
### Description

Replaced existing side navigation icon in AppLayout when one-theme is applied. 

https://github.com/user-attachments/assets/357d00fc-da68-426d-b1d6-e570bff95188




Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
