### PR TITLE
feat: add website token namespace to themed builds

### DIFF
--- a/src-themeable/__tests__/theming.test.ts
+++ b/src-themeable/__tests__/theming.test.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import mapValues from 'lodash/mapValues.js';
+import { join } from 'path';
+
+const preset = {
+  propertiesMap: {
+    borderRadiusButton: '--border-radius-button-aaaaaa',
+    colorBorderButtonNormalDefault: '--color-border-button-normal-default-bbbbbb',
+  },
+};
+
+jest.mock('@cloudscape-design/theming-build', () => ({
+  buildThemedComponents: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../internal/template/internal/generated/theming/index.cjs', () => ({
+  preset,
+}));
+
+import { buildThemedComponents as themingCoreBuild } from '@cloudscape-design/theming-build';
+
+import { buildThemedComponents } from '../theming';
+
+describe('buildThemedComponents', () => {
+  test('passes stable website token versions to theming build', async () => {
+    const theme = {} as any;
+
+    await buildThemedComponents({ theme, outputDir: '/tmp/output', baseThemeId: 'visual-refresh' });
+
+    expect(themingCoreBuild).toHaveBeenCalledWith({
+      override: theme,
+      preset: {
+        ...preset,
+        tokenVersions: mapValues(preset.propertiesMap, () => 'website'),
+      },
+      baseThemeId: 'visual-refresh',
+      componentsOutputDir: join('/tmp/output', 'components'),
+      designTokensOutputDir: join('/tmp/output', 'design-tokens'),
+      templateDir: join(__dirname, '../internal/template'),
+      designTokensTemplateDir: join(__dirname, '../internal/template-tokens'),
+      scssDir: join(__dirname, '../internal/scss'),
+    });
+  });
+});

--- a/src-themeable/__tests__/theming.test.ts
+++ b/src-themeable/__tests__/theming.test.ts
@@ -22,10 +22,29 @@ import { buildThemedComponents as themingCoreBuild } from '@cloudscape-design/th
 import { buildThemedComponents } from '../theming';
 
 describe('buildThemedComponents', () => {
-  test('passes stable website token versions to theming build', async () => {
+  test('does not pass website token versions by default', async () => {
     const theme = {} as any;
 
     await buildThemedComponents({ theme, outputDir: '/tmp/output', baseThemeId: 'visual-refresh' });
+
+    expect(themingCoreBuild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preset: {
+          ...preset,
+        },
+      })
+    );
+  });
+
+  test('passes stable website token versions when the feature flag is enabled', async () => {
+    const theme = {} as any;
+
+    await buildThemedComponents({
+      theme,
+      outputDir: '/tmp/output',
+      baseThemeId: 'visual-refresh',
+      useWebsiteTokenNamespace: true,
+    });
 
     expect(themingCoreBuild).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src-themeable/__tests__/theming.test.ts
+++ b/src-themeable/__tests__/theming.test.ts
@@ -43,7 +43,7 @@ describe('buildThemedComponents', () => {
       theme,
       outputDir: '/tmp/output',
       baseThemeId: 'visual-refresh',
-      useWebsiteTokenNamespace: true,
+      ...({ __tokenHashSeed: 'website' } as any),
     });
 
     expect(themingCoreBuild).toHaveBeenCalledWith(

--- a/src-themeable/__tests__/theming.test.ts
+++ b/src-themeable/__tests__/theming.test.ts
@@ -29,9 +29,7 @@ describe('buildThemedComponents', () => {
 
     expect(themingCoreBuild).toHaveBeenCalledWith(
       expect.objectContaining({
-        preset: {
-          ...preset,
-        },
+        preset,
       })
     );
   });
@@ -43,7 +41,7 @@ describe('buildThemedComponents', () => {
       theme,
       outputDir: '/tmp/output',
       baseThemeId: 'visual-refresh',
-      ...({ __tokenHashSeed: 'website' } as any),
+      ...{ __tokenHashSeed: 'website' },
     });
 
     expect(themingCoreBuild).toHaveBeenCalledWith(

--- a/src-themeable/__tests__/theming.test.ts
+++ b/src-themeable/__tests__/theming.test.ts
@@ -28,18 +28,13 @@ describe('buildThemedComponents', () => {
 
     await buildThemedComponents({ theme, outputDir: '/tmp/output', baseThemeId: 'visual-refresh' });
 
-    expect(themingCoreBuild).toHaveBeenCalledWith({
-      override: theme,
-      preset: {
-        ...preset,
-        tokenVersions: mapValues(preset.propertiesMap, () => 'website'),
-      },
-      baseThemeId: 'visual-refresh',
-      componentsOutputDir: join('/tmp/output', 'components'),
-      designTokensOutputDir: join('/tmp/output', 'design-tokens'),
-      templateDir: join(__dirname, '../internal/template'),
-      designTokensTemplateDir: join(__dirname, '../internal/template-tokens'),
-      scssDir: join(__dirname, '../internal/scss'),
-    });
+    expect(themingCoreBuild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preset: {
+          ...preset,
+          tokenVersions: mapValues(preset.propertiesMap, () => 'website'),
+        },
+      })
+    );
   });
 });

--- a/src-themeable/__tests__/theming.test.ts
+++ b/src-themeable/__tests__/theming.test.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import mapValues from 'lodash/mapValues.js';
-import { join } from 'path';
 
 const preset = {
   propertiesMap: {

--- a/src-themeable/theming.ts
+++ b/src-themeable/theming.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import mapValues from 'lodash/mapValues.js';
 import { join } from 'path';
 
 import { buildThemedComponents as themingCoreBuild } from '@cloudscape-design/theming-build';
@@ -21,7 +22,10 @@ export interface BuildThemedComponentsParams {
 export function buildThemedComponents({ theme, outputDir, baseThemeId }: BuildThemedComponentsParams): Promise<void> {
   return themingCoreBuild({
     override: theme,
-    preset,
+    preset: {
+      ...preset,
+      tokenVersions: mapValues(preset.propertiesMap, () => 'website'),
+    },
     baseThemeId,
     componentsOutputDir: join(outputDir, 'components'),
     designTokensOutputDir: join(outputDir, 'design-tokens'),

--- a/src-themeable/theming.ts
+++ b/src-themeable/theming.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import mapValues from 'lodash/mapValues.js';
 import { join } from 'path';
 
 import { buildThemedComponents as themingCoreBuild } from '@cloudscape-design/theming-build';
@@ -24,7 +23,7 @@ export function buildThemedComponents({ theme, outputDir, baseThemeId }: BuildTh
     override: theme,
     preset: {
       ...preset,
-      tokenVersions: mapValues(preset.propertiesMap, () => 'website'),
+      tokenVersions: Object.fromEntries(Object.entries(preset.propertiesMap).map(([token]) => [token, 'website'])),
     },
     baseThemeId,
     componentsOutputDir: join(outputDir, 'components'),

--- a/src-themeable/theming.ts
+++ b/src-themeable/theming.ts
@@ -16,24 +16,22 @@ export interface BuildThemedComponentsParams {
   theme: Theme;
   outputDir: string;
   baseThemeId?: string;
-  useWebsiteTokenNamespace?: boolean;
 }
 
 export function buildThemedComponents({
   theme,
   outputDir,
   baseThemeId,
-  useWebsiteTokenNamespace = false,
+  ...rest
 }: BuildThemedComponentsParams): Promise<void> {
+  const version = (rest as any).__tokenHashSeed;
   return themingCoreBuild({
     override: theme,
     preset: {
       ...preset,
-      ...(useWebsiteTokenNamespace
+      ...(version
         ? {
-            tokenVersions: Object.fromEntries(
-              Object.entries(preset.propertiesMap).map(([token]) => [token, 'website'])
-            ),
+            tokenVersions: Object.fromEntries(Object.entries(preset.propertiesMap).map(([token]) => [token, version])),
           }
         : {}),
     },

--- a/src-themeable/theming.ts
+++ b/src-themeable/theming.ts
@@ -24,6 +24,7 @@ export function buildThemedComponents({
   baseThemeId,
   ...rest
 }: BuildThemedComponentsParams): Promise<void> {
+  // Website-only escape hatch to avoid token hash collisions in generated output.
   const version = (rest as any).__tokenHashSeed;
   return themingCoreBuild({
     override: theme,

--- a/src-themeable/theming.ts
+++ b/src-themeable/theming.ts
@@ -16,14 +16,26 @@ export interface BuildThemedComponentsParams {
   theme: Theme;
   outputDir: string;
   baseThemeId?: string;
+  useWebsiteTokenNamespace?: boolean;
 }
 
-export function buildThemedComponents({ theme, outputDir, baseThemeId }: BuildThemedComponentsParams): Promise<void> {
+export function buildThemedComponents({
+  theme,
+  outputDir,
+  baseThemeId,
+  useWebsiteTokenNamespace = false,
+}: BuildThemedComponentsParams): Promise<void> {
   return themingCoreBuild({
     override: theme,
     preset: {
       ...preset,
-      tokenVersions: Object.fromEntries(Object.entries(preset.propertiesMap).map(([token]) => [token, 'website'])),
+      ...(useWebsiteTokenNamespace
+        ? {
+            tokenVersions: Object.fromEntries(
+              Object.entries(preset.propertiesMap).map(([token]) => [token, 'website'])
+            ),
+          }
+        : {}),
     },
     baseThemeId,
     componentsOutputDir: join(outputDir, 'components'),


### PR DESCRIPTION
## Summary
- add stable website tokenVersions when building themed components
- add a unit test that verifies the wrapper forwards the website namespace map
