### PR TITLE
feat: allow skipping secondary themes in themed builds

### DIFF
--- a/src-themeable/__tests__/theming.test.ts
+++ b/src-themeable/__tests__/theming.test.ts
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+const preset = {
+  secondary: [{ id: 'one-theme' }],
+};
+
+jest.mock('@cloudscape-design/theming-build', () => ({
+  buildThemedComponents: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../internal/template/internal/generated/theming/index.cjs', () => ({
+  preset,
+}));
+
+import { buildThemedComponents as themingCoreBuild } from '@cloudscape-design/theming-build';
+
+import { buildThemedComponents } from '../theming';
+
+describe('buildThemedComponents', () => {
+  test('passes secondary themes by default', async () => {
+    await buildThemedComponents({ theme: {} as any, outputDir: '/tmp/output', baseThemeId: 'visual-refresh' });
+
+    expect(themingCoreBuild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preset,
+      })
+    );
+  });
+
+  test('omits secondary themes when includeSecondaryThemes is false', async () => {
+    await buildThemedComponents({
+      theme: {} as any,
+      outputDir: '/tmp/output',
+      baseThemeId: 'visual-refresh',
+      includeSecondaryThemes: false,
+    });
+
+    expect(themingCoreBuild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preset: {
+          ...preset,
+          secondary: [],
+        },
+      })
+    );
+  });
+});

--- a/src-themeable/theming.ts
+++ b/src-themeable/theming.ts
@@ -16,12 +16,21 @@ export interface BuildThemedComponentsParams {
   theme: Theme;
   outputDir: string;
   baseThemeId?: string;
+  includeSecondaryThemes?: boolean;
 }
 
-export function buildThemedComponents({ theme, outputDir, baseThemeId }: BuildThemedComponentsParams): Promise<void> {
+export function buildThemedComponents({
+  theme,
+  outputDir,
+  baseThemeId,
+  includeSecondaryThemes = true,
+}: BuildThemedComponentsParams): Promise<void> {
   return themingCoreBuild({
     override: theme,
-    preset,
+    preset: {
+      ...preset,
+      secondary: includeSecondaryThemes ? preset.secondary : [],
+    },
     baseThemeId,
     componentsOutputDir: join(outputDir, 'components'),
     designTokensOutputDir: join(outputDir, 'design-tokens'),


### PR DESCRIPTION
## Summary
- add an optional `includeSecondaryThemes` parameter to `src-themeable/buildThemedComponents`
- default it to `true`, so existing consumers are unchanged
- when set to `false`, the wrapper forwards the preset with `secondary: []`
- this lets consumers build a themed package without generating secondary theme outputs
