### PR TITLE
fix: icon dash offset in safari

### DIFF
--- a/src/icon/__tests__/icon-hover-motion.test.ts
+++ b/src/icon/__tests__/icon-hover-motion.test.ts
@@ -152,6 +152,15 @@ describe('a malformed spec fails the build', () => {
     expect(missing).not.toBe(HOVER_MOTION_SOURCE);
     expect(() => compile([THEME], missing)).toThrow(/spec for `announcement` sets motion but is missing/);
   });
+
+  test('a negative stroke-dashoffset is rejected, naming the icon', () => {
+    // The first `56px` offset in the map belongs to `backward-10-seconds`.
+    const negative = HOVER_MOTION_SOURCE.replace('stroke-dashoffset: 56px,', 'stroke-dashoffset: -4px,');
+    expect(negative).not.toBe(HOVER_MOTION_SOURCE);
+    expect(() => compile([THEME], negative)).toThrow(
+      /spec for `backward-10-seconds` sets a negative `stroke-dashoffset`/
+    );
+  });
 });
 
 describe('keyframes', () => {
@@ -176,5 +185,13 @@ describe('keyframes', () => {
     for (const name of defined) {
       expect(referenced.has(name)).toBe(true);
     }
+  });
+
+  // Keyframes are literal CSS the sass-side spec validation cannot see, so the
+  // Safari negative-dash-offset guard is repeated here on the compiled output.
+  test('nothing in the compiled CSS sets a negative stroke-dashoffset (Safari mishandles them)', () => {
+    const css = compile([THEME]);
+    expect(css).toMatch(/stroke-dashoffset/);
+    expect(css).not.toMatch(/stroke-dashoffset:\s*-/);
   });
 });

--- a/src/icon/hover-motion.scss
+++ b/src/icon/hover-motion.scss
@@ -608,10 +608,10 @@ $icon-hover-motion: (
       property: stroke-dashoffset,
       base: (
         stroke-dasharray: 30,
-        stroke-dashoffset: 0,
+        stroke-dashoffset: 60px,
       ),
       to: (
-        stroke-dashoffset: -4px,
+        stroke-dashoffset: 56px,
       ),
     ),
     (
@@ -639,10 +639,10 @@ $icon-hover-motion: (
       property: stroke-dashoffset,
       base: (
         stroke-dasharray: 30,
-        stroke-dashoffset: 0,
+        stroke-dashoffset: 60px,
       ),
       to: (
-        stroke-dashoffset: -4px,
+        stroke-dashoffset: 56px,
       ),
     ),
     (
@@ -1382,10 +1382,10 @@ $icon-hover-motion: (
       property: stroke-dashoffset,
       base: (
         stroke-dasharray: 32 2,
-        stroke-dashoffset: 0,
+        stroke-dashoffset: 34px,
       ),
       to: (
-        stroke-dashoffset: -2px,
+        stroke-dashoffset: 32px,
       ),
     ),
     (
@@ -1739,11 +1739,11 @@ $icon-hover-motion: (
       0%,
       100% {
         stroke-dasharray: 7.4;
-        stroke-dashoffset: 0;
+        stroke-dashoffset: 14.8px;
       }
       50% {
         stroke-dasharray: 6, 7.4;
-        stroke-dashoffset: -0.7px;
+        stroke-dashoffset: 12.7px;
       }
     }
 
@@ -1751,11 +1751,11 @@ $icon-hover-motion: (
       0%,
       100% {
         stroke-dasharray: 7.4;
-        stroke-dashoffset: 0;
+        stroke-dashoffset: 14.8px;
       }
       50% {
         stroke-dasharray: 6, 7.4;
-        stroke-dashoffset: -0.7px;
+        stroke-dashoffset: 12.7px;
       }
     }
 
@@ -1847,11 +1847,11 @@ $icon-hover-motion: (
       40%,
       80%,
       100% {
-        stroke-dashoffset: 0;
+        stroke-dashoffset: 4px;
       }
       20%,
       60% {
-        stroke-dashoffset: -0.049px;
+        stroke-dashoffset: 3.951px;
       }
     }
 
@@ -2197,6 +2197,18 @@ $_spec-keys: (part, animation, to, base, origin, duration, easing, delay, iterat
         (map.get($spec, duration) and map.get($spec, easing))
       {
         @error 'The $icon-hover-motion spec for `#{$name}` sets motion but is missing `duration` or `easing`.';
+      }
+
+      // Safari mishandles negative dash offsets. This check validates no negative offsets exist.
+      // Instead of negative offsets, shift the offset up by one period to keep it positive.
+      @each $state in (base, to) {
+        $values: map.get($spec, $state) or ();
+        $offset: map.get($values, stroke-dashoffset);
+        @if meta.type-of($offset) == 'number' and $offset < 0 {
+          @error 'The $icon-hover-motion spec for `#{$name}` sets a negative `stroke-dashoffset`, ' +
+            'which Safari mishandles. Add one full dash period (the sum of the `stroke-dasharray` ' +
+            'values) to keep it positive — the rendering is identical.';
+        }
       }
     }
   }


### PR DESCRIPTION
### Description

Safari does not handle dash offsets properly. When animating icons with negative dash offsets, the movement is wrong:

https://github.com/user-attachments/assets/dac991b4-746d-4db1-b2bf-21f516a5756b

Fixed by moving all offsets by one period so the offset is not negative. Also added validation so no negative offsets can be added to the icon motion map.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
