### PR TITLE
fix: Refine jump-to-page input alignment in compact mode

### DIFF
--- a/src/pagination/styles.scss
+++ b/src/pagination/styles.scss
@@ -91,7 +91,7 @@
     inline-size: 87px;
     // This element contains the inline label and the HTML input element.
     // Push it upwards to let the HTML input element look vertically centered.
-    margin-block-start: calc(-2 * #{awsui.$space-scaled-xs});
+    margin-block-start: calc(-0.6em - #{awsui.$space-scaled-xs});
     overflow: visible;
   }
 }


### PR DESCRIPTION
### Description

Before (input field not vertically aligned with the text on the left)
<img width="251" height="40" alt="Screenshot 2026-09-08 at 22 37 05" src="https://github.com/user-attachments/assets/8cd9b721-0e52-4c30-8389-77387cf65097" />

After (vertically aligned as it used to before https://github.com/cloudscape-design/components/pull/4956)
<img width="256" height="44" alt="Screenshot 2026-09-08 at 22 36 48" src="https://github.com/user-attachments/assets/f0e946e5-a96d-4b94-bf38-42d8fa95eed4" />


### How has this been tested?

- In my pipeline
- Dry run: 8014553695

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
