### PR TITLE
feat: Add external breadcrumbs widget consumer

### DIFF
--- a/pages/app-layout/global-nav-breadcrumbs-hidden-instances-iframe.page.tsx
+++ b/pages/app-layout/global-nav-breadcrumbs-hidden-instances-iframe.page.tsx
@@ -1,0 +1,163 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useRef, useState } from 'react';
+
+import AppLayout from '~components/app-layout';
+import BreadcrumbGroup, { BreadcrumbGroupProps } from '~components/breadcrumb-group';
+import Button from '~components/button';
+import Header from '~components/header';
+import ScreenreaderOnly from '~components/internal/components/screenreader-only';
+import { registerBreadcrumbsConsumer } from '~components/internal/plugins/widget';
+import SideNavigation, { SideNavigationProps } from '~components/side-navigation';
+import SpaceBetween from '~components/space-between';
+
+import { IframeWrapper } from '../utils/iframe-wrapper';
+import ScreenshotArea from '../utils/screenshot-area';
+import appLayoutLabels from './utils/labels';
+
+// Router simulation, following multi-layout-with-hidden-instances-iframe: navigating away does not
+// unmount an App Layout, it hides it with `display: none`. So several producer instances stay mounted
+// at once, each in its own iframe (its own React root and document), and only one is visible.
+//
+// What to watch: the global consumer must show the VISIBLE instance's trail only. A hidden instance
+// stops publishing because AppLayoutVisibilityContext (driven by intersection) turns its breadcrumbs
+// registration off, so page 2 -- which passes no breadcrumbs -- must leave the header empty rather
+// than showing a stale trail from the hidden page 1. Unmount the header and App Layout resumes
+// drawing the visible instance's trail itself.
+
+function GlobalNavigationHeader() {
+  const [crumbs, setCrumbs] = useState<BreadcrumbGroupProps | null>(null);
+
+  useEffect(() => registerBreadcrumbsConsumer({ onBreadcrumbsChange: setCrumbs }).unregister, []);
+
+  // Sink mode: without this the consumer's own group would self-register and collapse to a skeleton.
+  const sinkProps = { ...crumbs, __disableGlobalization: true } as unknown as React.ComponentProps<
+    typeof BreadcrumbGroup
+  >;
+
+  return (
+    <div
+      data-testid="global-nav-header"
+      style={{
+        position: 'sticky',
+        insetBlockStart: 0,
+        zIndex: 1001,
+        padding: '8px 16px',
+        background: '#0f1b2d',
+        color: '#ffffff',
+      }}
+    >
+      <SpaceBetween size="m" direction="horizontal" alignItems="center">
+        <strong>Global Navigation (React root #1)</strong>
+        {crumbs ? (
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <BreadcrumbGroup {...sinkProps} />
+          </div>
+        ) : (
+          <span data-testid="global-nav-header-empty">No breadcrumbs published</span>
+        )}
+      </SpaceBetween>
+    </div>
+  );
+}
+
+function createView(name: string) {
+  return function View() {
+    return (
+      <AppLayout
+        {...{ __disableRuntimeDrawers: true }}
+        data-testid={`secondary-layout-${name}`}
+        ariaLabels={appLayoutLabels}
+        // page2 deliberately passes no breadcrumbs, so the header must go empty when it is active.
+        breadcrumbs={
+          name !== 'page2' && (
+            <BreadcrumbGroup
+              onFollow={event => event.preventDefault()}
+              items={[
+                { text: 'Home', href: '#' },
+                { text: name, href: `#${name}` },
+              ]}
+            />
+          )
+        }
+        navigationHide={true}
+        toolsHide={true}
+        content={
+          <SpaceBetween size="s">
+            <Header variant="h1" description="Separate React root inside an iframe">
+              {name}
+            </Header>
+            <div>
+              {name === 'page2'
+                ? 'This instance passes no breadcrumbs. The header above must be empty even though the other instances are still mounted (hidden).'
+                : 'This instance owns the trail while it is visible. Navigate away and it stays mounted but stops publishing.'}
+            </div>
+          </SpaceBetween>
+        }
+      />
+    );
+  };
+}
+
+const ROUTES: Array<{ navLink: SideNavigationProps.Link; View: React.ComponentType }> = [
+  { navLink: { type: 'link', text: 'Page 1', href: 'page1' }, View: createView('page1') },
+  { navLink: { type: 'link', text: 'Page 2 (no breadcrumbs)', href: 'page2' }, View: createView('page2') },
+  { navLink: { type: 'link', text: 'Page 3', href: 'page3' }, View: createView('page3') },
+];
+
+export default function GlobalNavBreadcrumbsHiddenInstancesPage() {
+  const [activeHref, setActiveHref] = useState('page1');
+  const [navHeaderMounted, setNavHeaderMounted] = useState(true);
+  const openPagesHistory = useRef<Set<string>>(new Set([activeHref]));
+
+  return (
+    <ScreenshotArea gutters={false}>
+      {/* Kept outside the header so the consumer can be unmounted and remounted. */}
+      <div style={{ padding: '8px 16px' }}>
+        <Button data-testid="toggle-nav-header" onClick={() => setNavHeaderMounted(mounted => !mounted)}>
+          {navHeaderMounted ? 'Unmount' : 'Mount'} global nav header
+        </Button>
+      </div>
+      {navHeaderMounted && <GlobalNavigationHeader />}
+      <AppLayout
+        {...{ __disableRuntimeDrawers: true }}
+        data-testid="main-layout"
+        ariaLabels={appLayoutLabels}
+        navigation={
+          <SideNavigation
+            activeHref={activeHref}
+            header={{ href: '#/', text: 'Service name' }}
+            onFollow={event => {
+              if (!event.detail.external) {
+                event.preventDefault();
+                openPagesHistory.current.add(event.detail.href);
+                setActiveHref(event.detail.href);
+              }
+            }}
+            items={ROUTES.map(route => route.navLink)}
+          />
+        }
+        toolsHide={true}
+        disableContentPaddings={true}
+        content={
+          <>
+            <ScreenreaderOnly>
+              <h1>Global breadcrumbs with hidden app layout instances in iframes</h1>
+            </ScreenreaderOnly>
+            {ROUTES.filter(
+              item => item.navLink.href === activeHref || openPagesHistory.current.has(item.navLink.href)
+            ).map(item => (
+              <div
+                key={item.navLink.href}
+                data-testid={`instance-${item.navLink.href}`}
+                style={{ display: item.navLink.href !== activeHref ? 'none' : '' }}
+              >
+                <IframeWrapper id={item.navLink.href} AppComponent={item.View} />
+              </div>
+            ))}
+          </>
+        }
+      />
+    </ScreenshotArea>
+  );
+}

--- a/pages/app-layout/global-nav-breadcrumbs-multi-instance.page.tsx
+++ b/pages/app-layout/global-nav-breadcrumbs-multi-instance.page.tsx
@@ -1,0 +1,158 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useState } from 'react';
+
+import AppLayout from '~components/app-layout';
+import BreadcrumbGroup, { BreadcrumbGroupProps } from '~components/breadcrumb-group';
+import Button from '~components/button';
+import Container from '~components/container';
+import Header from '~components/header';
+import { registerBreadcrumbsConsumer } from '~components/internal/plugins/widget';
+import SpaceBetween from '~components/space-between';
+
+import { IframeWrapper } from '../utils/iframe-wrapper';
+import labels from './utils/labels';
+
+// Closest simulation of the real console topology: the Global Navigation header and each App Layout
+// live in SEPARATE React roots (separate `mount()` calls, separate documents). They still share one
+// breadcrumb channel because the widget registry and BreadcrumbsController both reuse state from
+// the highest accessible same-origin window.
+
+function GlobalNavigationHeader() {
+  const [crumbs, setCrumbs] = useState<BreadcrumbGroupProps | null>(null);
+
+  useEffect(() => registerBreadcrumbsConsumer({ onBreadcrumbsChange: setCrumbs }).unregister, []);
+
+  const sinkProps = { ...crumbs, __disableGlobalization: true } as unknown as React.ComponentProps<
+    typeof BreadcrumbGroup
+  >;
+
+  return (
+    <div
+      data-testid="global-nav-header"
+      style={{
+        position: 'sticky',
+        insetBlockStart: 0,
+        zIndex: 1001,
+        padding: '8px 16px',
+        background: '#0f1b2d',
+        color: '#ffffff',
+      }}
+    >
+      <SpaceBetween size="m" direction="horizontal" alignItems="center">
+        <strong>Global Navigation (React root #1)</strong>
+        {crumbs ? (
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <BreadcrumbGroup {...sinkProps} />
+          </div>
+        ) : (
+          <span data-testid="global-nav-header-empty">No breadcrumbs published</span>
+        )}
+      </SpaceBetween>
+    </div>
+  );
+}
+
+// Producer app mounted into an iframe by IframeWrapper -- its own React root, its own document.
+function makeProducerApp(name: string, testId: string) {
+  return function ProducerApp() {
+    const [depth, setDepth] = useState(2);
+    const items = [
+      { text: 'Home', href: '#home' },
+      { text: name, href: '#service' },
+      ...Array.from({ length: depth - 2 }, (_unused, index) => ({
+        text: `${name} level ${index + 2}`,
+        href: '#',
+      })),
+    ];
+
+    return (
+      <AppLayout
+        {...{ __disableRuntimeDrawers: true }}
+        data-testid={testId}
+        ariaLabels={labels}
+        breadcrumbs={<BreadcrumbGroup items={items} ariaLabel={`${name} breadcrumbs`} />}
+        navigationHide={true}
+        toolsHide={true}
+        content={
+          <SpaceBetween size="s">
+            <Header variant="h2" description="Separate React root inside an iframe">
+              {name}
+            </Header>
+            <Button data-testid={`append-${testId}`} onClick={() => setDepth(current => current + 1)}>
+              Append to {name}
+            </Button>
+          </SpaceBetween>
+        }
+      />
+    );
+  };
+}
+
+const AlphaApp = makeProducerApp('Alpha service', 'iframe-layout-alpha');
+const BetaApp = makeProducerApp('Beta service', 'iframe-layout-beta');
+
+// Visible boundary so it is obvious where one React instance ends and the next begins.
+function IframeInstance({ id, label, AppComponent }: { id: string; label: string; AppComponent: React.ComponentType }) {
+  return (
+    <div style={{ border: '2px dashed #7d8998', borderRadius: 8, padding: 8 }}>
+      <div style={{ marginBlockEnd: 8, fontSize: 12, fontWeight: 700, color: '#5f6b7a' }}>
+        {label} &mdash; <code>&lt;iframe id=&quot;{id}&quot;&gt;</code>
+      </div>
+      <div style={{ blockSize: 260 }}>
+        <IframeWrapper id={id} AppComponent={AppComponent} />
+      </div>
+    </div>
+  );
+}
+
+export default function GlobalNavBreadcrumbsMultiInstancePage() {
+  const [navHeaderMounted, setNavHeaderMounted] = useState(true);
+  const [alphaMounted, setAlphaMounted] = useState(true);
+  const [betaMounted, setBetaMounted] = useState(false);
+
+  return (
+    <>
+      {navHeaderMounted && <GlobalNavigationHeader />}
+      <AppLayout
+        data-testid="main-layout"
+        ariaLabels={labels}
+        toolsHide={true}
+        content={
+          <SpaceBetween size="m">
+            <Container header={<Header variant="h1">Multiple React instances, one global consumer</Header>}>
+              <SpaceBetween size="s">
+                <p>
+                  Open with <code>?visualRefresh=true&amp;appLayoutToolbar=true</code>. Each producer App Layout is
+                  mounted into its own iframe with its own <code>mount()</code> React root &mdash; independent React
+                  instances, independent documents, exactly like the console&apos;s Global Navigation and App Layout
+                  bundles.
+                </p>
+                <p>
+                  The widget API resolves its registry from the highest accessible same-origin window, while the
+                  existing plugin API shares its breadcrumb controller the same way. A breadcrumb registered inside an
+                  iframe therefore reaches the header in the parent root. The first active producer remains selected
+                  until it unmounts, then the next producer takes over.
+                </p>
+                <SpaceBetween size="xs" direction="horizontal">
+                  <Button data-testid="toggle-nav-header" onClick={() => setNavHeaderMounted(mounted => !mounted)}>
+                    {navHeaderMounted ? 'Unmount' : 'Mount'} global nav header
+                  </Button>
+                  <Button data-testid="toggle-iframe-alpha" onClick={() => setAlphaMounted(mounted => !mounted)}>
+                    {alphaMounted ? 'Unmount' : 'Mount'} Alpha iframe
+                  </Button>
+                  <Button data-testid="toggle-iframe-beta" onClick={() => setBetaMounted(mounted => !mounted)}>
+                    {betaMounted ? 'Unmount' : 'Mount'} Beta iframe
+                  </Button>
+                </SpaceBetween>
+              </SpaceBetween>
+            </Container>
+
+            {alphaMounted && <IframeInstance id="iframe-alpha" label="React root #2" AppComponent={AlphaApp} />}
+            {betaMounted && <IframeInstance id="iframe-beta" label="React root #3" AppComponent={BetaApp} />}
+          </SpaceBetween>
+        }
+      />
+    </>
+  );
+}

--- a/pages/app-layout/global-nav-breadcrumbs-multi-layout.page.tsx
+++ b/pages/app-layout/global-nav-breadcrumbs-multi-layout.page.tsx
@@ -1,0 +1,162 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useState } from 'react';
+
+import AppLayout from '~components/app-layout';
+import BreadcrumbGroup, { BreadcrumbGroupProps } from '~components/breadcrumb-group';
+import Button from '~components/button';
+import Container from '~components/container';
+import Header from '~components/header';
+import { registerBreadcrumbsConsumer } from '~components/internal/plugins/widget';
+import SpaceBetween from '~components/space-between';
+
+import labels from './utils/labels';
+
+// Same simulated console Global Navigation header as global-nav-breadcrumbs.page.tsx: it consumes
+// the `registerBreadcrumbsConsumer` widget API and renders in sink mode (__disableGlobalization)
+// so its own render never re-registers. Here it is the single consumer for SEVERAL App Layouts.
+
+function GlobalNavigationHeader() {
+  const [crumbs, setCrumbs] = useState<BreadcrumbGroupProps | null>(null);
+
+  useEffect(() => registerBreadcrumbsConsumer({ onBreadcrumbsChange: setCrumbs }).unregister, []);
+
+  const sinkProps = { ...crumbs, __disableGlobalization: true } as unknown as React.ComponentProps<
+    typeof BreadcrumbGroup
+  >;
+
+  return (
+    <div
+      data-testid="global-nav-header"
+      style={{
+        position: 'sticky',
+        insetBlockStart: 0,
+        zIndex: 1001,
+        padding: '8px 16px',
+        background: '#0f1b2d',
+        color: '#ffffff',
+      }}
+    >
+      <SpaceBetween size="m" direction="horizontal" alignItems="center">
+        <strong>Global Navigation (simulated header)</strong>
+        {crumbs ? (
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <BreadcrumbGroup {...sinkProps} />
+          </div>
+        ) : (
+          <span data-testid="global-nav-header-empty">No breadcrumbs published</span>
+        )}
+      </SpaceBetween>
+    </div>
+  );
+}
+
+// A secondary App Layout standing in for one console page's layout. It passes its own trail to the
+// `breadcrumbs` slot, so the slotted BreadcrumbGroup self-registers on the shared channel.
+function SecondaryLayout({
+  name,
+  testId,
+  mounted,
+  onToggle,
+}: {
+  name: string;
+  testId: string;
+  mounted: boolean;
+  onToggle: () => void;
+}) {
+  const [depth, setDepth] = useState(2);
+  const items = [
+    { text: 'Home', href: '#home' },
+    { text: name, href: '#service' },
+    ...Array.from({ length: depth - 2 }, (_unused, index) => ({
+      text: `${name} level ${index + 2}`,
+      href: '#',
+    })),
+  ];
+
+  if (!mounted) {
+    return (
+      <Container header={<Header variant="h2">{name} (unmounted)</Header>}>
+        <Button data-testid={`toggle-${testId}`} onClick={onToggle}>
+          Mount {name}
+        </Button>
+      </Container>
+    );
+  }
+
+  return (
+    <AppLayout
+      {...{ __disableRuntimeDrawers: true }}
+      data-testid={testId}
+      ariaLabels={labels}
+      breadcrumbs={<BreadcrumbGroup items={items} ariaLabel={`${name} breadcrumbs`} />}
+      navigationHide={true}
+      toolsHide={true}
+      content={
+        <SpaceBetween size="s">
+          <Header variant="h2">{name}</Header>
+          <SpaceBetween size="xs" direction="horizontal">
+            <Button data-testid={`append-${testId}`} onClick={() => setDepth(current => current + 1)}>
+              Append to {name}
+            </Button>
+            <Button data-testid={`toggle-${testId}`} onClick={onToggle}>
+              Unmount {name}
+            </Button>
+          </SpaceBetween>
+        </SpaceBetween>
+      }
+    />
+  );
+}
+
+export default function GlobalNavBreadcrumbsMultiLayoutPage() {
+  const [navHeaderMounted, setNavHeaderMounted] = useState(true);
+  const [alphaMounted, setAlphaMounted] = useState(true);
+  const [betaMounted, setBetaMounted] = useState(true);
+
+  return (
+    <>
+      {navHeaderMounted && <GlobalNavigationHeader />}
+      <AppLayout
+        data-testid="main-layout"
+        ariaLabels={labels}
+        toolsHide={true}
+        disableContentPaddings={true}
+        content={
+          <SpaceBetween size="m">
+            <Container header={<Header variant="h1">Multiple App Layouts, one global consumer</Header>}>
+              <SpaceBetween size="s">
+                <p>
+                  Open with <code>?visualRefresh=true&amp;appLayoutToolbar=true</code>. An outer App Layout hosts two
+                  secondary App Layouts, each passing its own <code>&lt;BreadcrumbGroup&gt;</code> to its{' '}
+                  <code>breadcrumbs</code> slot. All of them register on the same shared channel, and the single
+                  simulated Global Navigation header receives the most recently registered trail.
+                </p>
+                <p>
+                  Unmount the newest producer to test fallback to the previous layout. Unmount the header and App
+                  Layout&apos;s existing coordination renders one trail in its toolbar.
+                </p>
+                <Button data-testid="toggle-nav-header" onClick={() => setNavHeaderMounted(mounted => !mounted)}>
+                  {navHeaderMounted ? 'Unmount' : 'Mount'} global nav header
+                </Button>
+              </SpaceBetween>
+            </Container>
+
+            <SecondaryLayout
+              name="Alpha service"
+              testId="secondary-layout-alpha"
+              mounted={alphaMounted}
+              onToggle={() => setAlphaMounted(mounted => !mounted)}
+            />
+            <SecondaryLayout
+              name="Beta service"
+              testId="secondary-layout-beta"
+              mounted={betaMounted}
+              onToggle={() => setBetaMounted(mounted => !mounted)}
+            />
+          </SpaceBetween>
+        }
+      />
+    </>
+  );
+}

--- a/pages/app-layout/global-nav-breadcrumbs.page.tsx
+++ b/pages/app-layout/global-nav-breadcrumbs.page.tsx
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useState } from 'react';
+
+import AppLayout from '~components/app-layout';
+import BreadcrumbGroup, { BreadcrumbGroupProps } from '~components/breadcrumb-group';
+import Button from '~components/button';
+import Container from '~components/container';
+import Header from '~components/header';
+import { registerBreadcrumbsConsumer } from '~components/internal/plugins/widget';
+import SpaceBetween from '~components/space-between';
+
+import labels from './utils/labels';
+
+// Simulates the console Global Navigation module hosting App Layout breadcrumbs in its own
+// header. It consumes the `registerBreadcrumbsConsumer` widget API and renders its own
+// BreadcrumbGroup in sink mode (__disableGlobalization) so this render never re-registers.
+
+function GlobalNavigationHeader() {
+  const [crumbs, setCrumbs] = useState<BreadcrumbGroupProps | null>(null);
+
+  // Fires immediately with the current value, then on every change. `registered` is false if another
+  // consumer already owns rendering.
+  useEffect(() => registerBreadcrumbsConsumer({ onBreadcrumbsChange: setCrumbs }).unregister, []);
+
+  const sinkProps = { ...crumbs, __disableGlobalization: true } as unknown as React.ComponentProps<
+    typeof BreadcrumbGroup
+  >;
+
+  return (
+    <div
+      data-testid="global-nav-header"
+      style={{
+        position: 'sticky',
+        insetBlockStart: 0,
+        zIndex: 1001,
+        padding: '8px 16px',
+        background: '#0f1b2d',
+        color: '#ffffff',
+      }}
+    >
+      <SpaceBetween size="m" direction="horizontal" alignItems="center">
+        <strong>Global Navigation (simulated header)</strong>
+        {crumbs ? (
+          // flex:1 + min-width:0 gives BreadcrumbGroup the full remaining width to measure,
+          // so it renders the whole trail instead of collapsing to a dropdown.
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <BreadcrumbGroup {...sinkProps} />
+          </div>
+        ) : (
+          <span data-testid="global-nav-header-empty">No breadcrumbs published</span>
+        )}
+      </SpaceBetween>
+    </div>
+  );
+}
+
+export default function GlobalNavBreadcrumbsPage() {
+  const [navHeaderMounted, setNavHeaderMounted] = useState(true);
+  const [items, setItems] = useState<BreadcrumbGroupProps['items']>([
+    { text: 'Home', href: '#home' },
+    { text: 'Service', href: '#service' },
+    { text: 'Resource', href: '#resource' },
+  ]);
+
+  return (
+    <>
+      {navHeaderMounted && <GlobalNavigationHeader />}
+      <AppLayout
+        ariaLabels={labels}
+        // Producer: a console page passes its breadcrumbs to App Layout's slot (standard usage).
+        breadcrumbs={<BreadcrumbGroup items={items} ariaLabel="Breadcrumbs" />}
+        content={
+          <SpaceBetween size="m">
+            <Header variant="h1">Global nav breadcrumbs demo</Header>
+
+            <Container header={<Header variant="h2">How to view</Header>}>
+              <SpaceBetween size="s">
+                <p>
+                  Open this page with <code>?visualRefresh=true&amp;appLayoutToolbar=true</code> so global breadcrumbs
+                  are active. The page passes its <code>&lt;BreadcrumbGroup&gt;</code> to App Layout&apos;s
+                  <code>breadcrumbs</code> slot.
+                </p>
+                <p>
+                  While the simulated Global Navigation header is mounted it registers as an external consumer, so App
+                  Layout <strong>auto-yields</strong> (stops rendering breadcrumbs in its toolbar) and the header
+                  renders them instead. Unmount the header and App Layout resumes.
+                </p>
+                <p>
+                  &ldquo;Load global nav late&rdquo; reproduces the real console ordering, where App Layout is up before
+                  Global Navigation loads. App Layout initially owns the trail, then yields it when the widget consumer
+                  registers.
+                </p>
+                <SpaceBetween size="xs" direction="horizontal">
+                  <Button data-testid="toggle-nav-header" onClick={() => setNavHeaderMounted(mounted => !mounted)}>
+                    {navHeaderMounted ? 'Unmount' : 'Mount'} global nav header
+                  </Button>
+                  <Button
+                    data-testid="delay-nav-header"
+                    onClick={() => {
+                      setNavHeaderMounted(false);
+                      setTimeout(() => setNavHeaderMounted(true), 1500);
+                    }}
+                  >
+                    Load global nav late
+                  </Button>
+                  <Button
+                    data-testid="append-breadcrumb"
+                    onClick={() => setItems(current => [...current, { text: `Level ${current.length}`, href: '#' }])}
+                  >
+                    Append a breadcrumb
+                  </Button>
+                </SpaceBetween>
+              </SpaceBetween>
+            </Container>
+          </SpaceBetween>
+        }
+      />
+    </>
+  );
+}

--- a/src/app-layout/__integ__/global-nav-breadcrumbs-consumer.test.ts
+++ b/src/app-layout/__integ__/global-nav-breadcrumbs-consumer.test.ts
@@ -1,0 +1,159 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import { getUrlParams } from './utils';
+
+const theme = 'refresh-toolbar';
+
+const globalNavHeader = createWrapper().find('[data-testid="global-nav-header"]');
+const consumerBreadcrumbs = globalNavHeader.findBreadcrumbGroup();
+const appLayoutBreadcrumbs = createWrapper().findAppLayout().findBreadcrumbs();
+const mainLayoutBreadcrumbs = createWrapper().find('[data-testid="main-layout"]').findAppLayout().findBreadcrumbs();
+
+class GlobalNavBreadcrumbsPage extends BasePageObject {
+  clickTestId(testId: string) {
+    return this.click(`[data-testid="${testId}"]`);
+  }
+
+  clickHref(href: string) {
+    return this.click(`[href="${href}"]`);
+  }
+
+  hasConsumerBreadcrumbs() {
+    return this.isExisting(consumerBreadcrumbs.toSelector());
+  }
+
+  getConsumerBreadcrumbsText() {
+    return this.getText(consumerBreadcrumbs.toSelector());
+  }
+
+  hasAppLayoutBreadcrumbs() {
+    return this.isExisting(appLayoutBreadcrumbs.findBreadcrumbGroup().toSelector());
+  }
+
+  hasMainLayoutBreadcrumbs() {
+    return this.isExisting(mainLayoutBreadcrumbs.findBreadcrumbGroup().toSelector());
+  }
+
+  /** Number of breadcrumb groups anywhere on the page -- exactly one trail must be visible at a time. */
+  getBreadcrumbGroupsCount() {
+    return this.getElementsCount(createWrapper().findBreadcrumbGroup().toSelector());
+  }
+}
+
+function setupTest(
+  page: string,
+  params: Record<string, string>,
+  testFn: (page: GlobalNavBreadcrumbsPage) => Promise<void>
+) {
+  return useBrowser(async browser => {
+    const pageObject = new GlobalNavBreadcrumbsPage(browser);
+    await browser.url(`#/light/app-layout/${page}?${getUrlParams(theme, params)}`);
+    await pageObject.waitForVisible(createWrapper().findAppLayout().findContentRegion().toSelector());
+    await testFn(pageObject);
+  });
+}
+
+describe('global breadcrumbs consumer', () => {
+  test(
+    'consumer draws the trail while registered, App Layout resumes when it unmounts',
+    setupTest('global-nav-breadcrumbs', {}, async page => {
+      await page.waitForVisible(consumerBreadcrumbs.toSelector());
+      await expect(page.getConsumerBreadcrumbsText()).resolves.toContain('Resource');
+      // The consumer owns rendering, so App Layout draws nothing and only one trail exists.
+      await expect(page.hasAppLayoutBreadcrumbs()).resolves.toBe(false);
+      await expect(page.getBreadcrumbGroupsCount()).resolves.toBe(1);
+
+      await page.clickTestId('toggle-nav-header');
+      await page.waitForVisible(appLayoutBreadcrumbs.findBreadcrumbGroup().toSelector());
+      await expect(page.hasConsumerBreadcrumbs()).resolves.toBe(false);
+      await expect(page.getBreadcrumbGroupsCount()).resolves.toBe(1);
+
+      await page.clickTestId('toggle-nav-header');
+      await page.waitForVisible(consumerBreadcrumbs.toSelector());
+      await expect(page.hasAppLayoutBreadcrumbs()).resolves.toBe(false);
+    })
+  );
+
+  test(
+    'the consumer receives producer updates',
+    setupTest('global-nav-breadcrumbs', {}, async page => {
+      await page.waitForVisible(consumerBreadcrumbs.toSelector());
+      await expect(page.getConsumerBreadcrumbsText()).resolves.not.toContain('Level 3');
+
+      await page.clickTestId('append-breadcrumb');
+      await expect(page.getConsumerBreadcrumbsText()).resolves.toContain('Level 3');
+    })
+  );
+
+  test(
+    'coordinates breadcrumbs from multiple App Layout instances',
+    setupTest('global-nav-breadcrumbs-multi-layout', {}, async page => {
+      await page.waitForVisible(consumerBreadcrumbs.toSelector());
+      await expect(page.getConsumerBreadcrumbsText()).resolves.toContain('Beta service');
+      await expect(page.getBreadcrumbGroupsCount()).resolves.toBe(1);
+
+      await page.clickTestId('toggle-secondary-layout-beta');
+      await page.waitForAssertion(() => expect(page.getConsumerBreadcrumbsText()).resolves.toContain('Alpha service'));
+
+      await page.clickTestId('toggle-nav-header');
+      await page.waitForAssertion(() => expect(page.getBreadcrumbGroupsCount()).resolves.toBe(1));
+    })
+  );
+
+  test(
+    'coordinates producers mounted in separate iframe roots',
+    setupTest('global-nav-breadcrumbs-multi-instance', {}, async page => {
+      await page.waitForVisible(consumerBreadcrumbs.toSelector());
+      await expect(page.getConsumerBreadcrumbsText()).resolves.toContain('Alpha service');
+
+      await page.clickTestId('toggle-iframe-beta');
+      await expect(page.getConsumerBreadcrumbsText()).resolves.toContain('Alpha service');
+
+      await page.clickTestId('toggle-iframe-alpha');
+      await page.waitForAssertion(() => expect(page.getConsumerBreadcrumbsText()).resolves.toContain('Beta service'));
+      await expect(page.getBreadcrumbGroupsCount()).resolves.toBe(1);
+    })
+  );
+
+  describe('with hidden app layout instances in iframes', () => {
+    const hiddenInstances = (testFn: (page: GlobalNavBreadcrumbsPage) => Promise<void>) =>
+      setupTest('global-nav-breadcrumbs-hidden-instances-iframe', {}, testFn);
+
+    test(
+      'only the visible instance publishes to the consumer',
+      hiddenInstances(async page => {
+        await page.waitForVisible(consumerBreadcrumbs.toSelector());
+        await expect(page.getConsumerBreadcrumbsText()).resolves.toContain('page1');
+
+        // page2 passes no breadcrumbs. page1 stays mounted but hidden, so it must stop publishing
+        // rather than leaving a stale trail in the consumer.
+        await page.clickHref('page2');
+        await page.waitForAssertion(() => expect(page.hasConsumerBreadcrumbs()).resolves.toBe(false));
+
+        await page.clickHref('page3');
+        await page.waitForVisible(consumerBreadcrumbs.toSelector());
+        await expect(page.getConsumerBreadcrumbsText()).resolves.toContain('page3');
+
+        await page.clickHref('page1');
+        await page.waitForAssertion(() => expect(page.getConsumerBreadcrumbsText()).resolves.toContain('page1'));
+      })
+    );
+
+    test(
+      'App Layout draws the visible instance trail once the consumer unmounts',
+      hiddenInstances(async page => {
+        await page.waitForVisible(consumerBreadcrumbs.toSelector());
+        await expect(page.hasMainLayoutBreadcrumbs()).resolves.toBe(false);
+
+        await page.clickTestId('toggle-nav-header');
+        await page.waitForVisible(mainLayoutBreadcrumbs.findBreadcrumbGroup().toSelector());
+        await expect(page.getText(mainLayoutBreadcrumbs.toSelector())).resolves.toContain('page1');
+        await expect(page.getBreadcrumbGroupsCount()).resolves.toBe(1);
+      })
+    );
+  });
+});

--- a/src/app-layout/__tests__/runtime-breadcrumbs-widgetized.test.tsx
+++ b/src/app-layout/__tests__/runtime-breadcrumbs-widgetized.test.tsx
@@ -62,6 +62,26 @@ afterEach(() => {
   });
 });
 
+test('shares the consumer registry with a same-origin parent window', () => {
+  const originalParentDescriptor = Object.getOwnPropertyDescriptor(window, 'parent')!;
+  const parentWindow = {} as Window;
+  Object.defineProperty(parentWindow, 'parent', { value: parentWindow });
+  Object.defineProperty(window, 'parent', { configurable: true, value: parentWindow });
+  let unregister = () => {};
+
+  try {
+    const first = widgetPlugins.registerBreadcrumbsConsumer({ onBreadcrumbsChange: jest.fn() });
+    unregister = first.unregister;
+    const second = widgetPlugins.registerBreadcrumbsConsumer({ onBreadcrumbsChange: jest.fn() });
+
+    expect(first.registered).toBe(true);
+    expect(second.registered).toBe(false);
+  } finally {
+    unregister();
+    Object.defineProperty(window, 'parent', originalParentDescriptor);
+  }
+});
+
 describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
   test('renders slot breadcrumbs in an external container and restores App Layout on unregister', async () => {
     const externalContainer = document.createElement('div');

--- a/src/app-layout/__tests__/runtime-breadcrumbs-widgetized.test.tsx
+++ b/src/app-layout/__tests__/runtime-breadcrumbs-widgetized.test.tsx
@@ -1,0 +1,208 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+
+import AppLayout from '../../../lib/components/app-layout';
+import BreadcrumbGroup, { BreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group';
+import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import * as widgetPlugins from '../../../lib/components/internal/plugins/widget';
+import { clearBreadcrumbsConsumer } from '../../../lib/components/internal/plugins/widget/core';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { describeEachAppLayout } from './utils';
+
+const wrapper = createWrapper();
+const defaultItems: BreadcrumbGroupProps['items'] = [
+  { text: 'Home', href: '/home' },
+  { text: 'Resource', href: '/resource' },
+];
+
+function getAppLayoutBreadcrumbGroup() {
+  return wrapper.findAppLayout()?.findBreadcrumbs()?.findBreadcrumbGroup();
+}
+
+function registerExternalContainer(container: HTMLElement) {
+  const received: Array<BreadcrumbGroupProps | null> = [];
+  const registration = widgetPlugins.registerBreadcrumbsConsumer({
+    onBreadcrumbsChange: breadcrumbs => {
+      received.push(breadcrumbs);
+      container.textContent = breadcrumbs?.items.map(item => item.text).join(' / ') ?? '';
+    },
+  });
+  return { received, registration };
+}
+
+function ExternalBreadcrumbGroup() {
+  const [breadcrumbs, setBreadcrumbs] = React.useState<BreadcrumbGroupProps | null>(null);
+
+  React.useEffect(
+    () => widgetPlugins.registerBreadcrumbsConsumer({ onBreadcrumbsChange: setBreadcrumbs }).unregister,
+    []
+  );
+
+  if (!breadcrumbs) {
+    return null;
+  }
+
+  const sinkProps = { ...breadcrumbs, __disableGlobalization: true } as React.ComponentProps<typeof BreadcrumbGroup>;
+  return <BreadcrumbGroup {...sinkProps} />;
+}
+
+beforeEach(() => {
+  clearBreadcrumbsConsumer();
+});
+
+afterEach(() => {
+  cleanup();
+  clearBreadcrumbsConsumer();
+  expect(awsuiPluginsInternal.breadcrumbs.getStateForTesting()).toEqual({
+    appLayoutUpdateCallback: null,
+    breadcrumbInstances: [],
+    breadcrumbRegistrations: [],
+  });
+});
+
+describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
+  test('renders slot breadcrumbs in an external container and restores App Layout on unregister', async () => {
+    const externalContainer = document.createElement('div');
+    document.body.appendChild(externalContainer);
+    const { received, registration } = registerExternalContainer(externalContainer);
+
+    expect(received).toEqual([null]);
+
+    render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultItems} />} />);
+
+    await waitFor(() => expect(externalContainer).toHaveTextContent('Home / Resource'));
+    expect(getAppLayoutBreadcrumbGroup()).toBeFalsy();
+
+    act(() => registration.unregister());
+    await waitFor(() => expect(getAppLayoutBreadcrumbGroup()).toBeTruthy());
+    externalContainer.remove();
+  });
+
+  test('preserves the producing BreadcrumbGroup event handlers', async () => {
+    const onFollow = jest.fn();
+    const externalContainer = document.createElement('div');
+    const { received } = registerExternalContainer(externalContainer);
+
+    render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultItems} onFollow={onFollow} />} />);
+
+    await waitFor(() => expect(received[received.length - 1]?.items).toEqual(defaultItems));
+    expect(received[received.length - 1]?.onFollow).toBe(onFollow);
+  });
+
+  test('publishes updates to slot breadcrumbs without replacing the consumer', async () => {
+    const externalContainer = document.createElement('div');
+    const { received } = registerExternalContainer(externalContainer);
+    const { rerender } = render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultItems} />} />);
+
+    await waitFor(() => expect(received[received.length - 1]?.items).toEqual(defaultItems));
+
+    const updatedItems = [{ text: 'Updated', href: '/updated' }];
+    rerender(<AppLayout breadcrumbs={<BreadcrumbGroup items={updatedItems} />} />);
+
+    await waitFor(() => expect(received[received.length - 1]?.items).toEqual(updatedItems));
+  });
+
+  test('renders a non-registering BreadcrumbGroup in a separate React root', async () => {
+    const onFollow = jest.fn(event => event.preventDefault());
+    render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultItems} onFollow={onFollow} />} />);
+    await waitFor(() => expect(getAppLayoutBreadcrumbGroup()).toBeTruthy());
+
+    const externalContainer = document.createElement('div');
+    document.body.appendChild(externalContainer);
+    const externalRoot = render(<ExternalBreadcrumbGroup />, { container: externalContainer });
+
+    const externalWrapper = createWrapper(externalContainer);
+    await waitFor(() => expect(externalWrapper.findBreadcrumbGroup()).toBeTruthy());
+    expect(getAppLayoutBreadcrumbGroup()).toBeFalsy();
+
+    externalWrapper.findBreadcrumbGroup()!.findBreadcrumbLink(1)!.click();
+    expect(onFollow).toHaveBeenCalledTimes(1);
+    externalRoot.unmount();
+    externalContainer.remove();
+  });
+
+  test('moves discovered breadcrumbs outside App Layout and publishes updates', async () => {
+    const externalContainer = document.createElement('div');
+    document.body.appendChild(externalContainer);
+    registerExternalContainer(externalContainer);
+
+    const { rerender } = render(
+      <AppLayout content={<BreadcrumbGroup items={[{ text: 'Original', href: '/original' }]} />} />
+    );
+
+    await waitFor(() => expect(externalContainer).toHaveTextContent('Original'));
+    expect(getAppLayoutBreadcrumbGroup()).toBeFalsy();
+
+    rerender(<AppLayout content={<BreadcrumbGroup items={[{ text: 'Changed', href: '/changed' }]} />} />);
+    await waitFor(() => expect(externalContainer).toHaveTextContent('Changed'));
+    expect(getAppLayoutBreadcrumbGroup()).toBeFalsy();
+    externalContainer.remove();
+  });
+
+  test('supports a consumer that registers after App Layout mounts', async () => {
+    render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultItems} />} />);
+    await waitFor(() => expect(getAppLayoutBreadcrumbGroup()).toBeTruthy());
+
+    const externalContainer = document.createElement('div');
+    document.body.appendChild(externalContainer);
+    act(() => {
+      registerExternalContainer(externalContainer);
+    });
+
+    await waitFor(() => expect(externalContainer).toHaveTextContent('Home / Resource'));
+    expect(getAppLayoutBreadcrumbGroup()).toBeFalsy();
+    externalContainer.remove();
+  });
+
+  test('keeps unsupported custom breadcrumb content in App Layout', async () => {
+    const onBreadcrumbsChange = jest.fn();
+    widgetPlugins.registerBreadcrumbsConsumer({ onBreadcrumbsChange });
+
+    render(<AppLayout breadcrumbs={<div data-testid="custom-breadcrumbs">Custom breadcrumbs</div>} />);
+
+    await waitFor(() => expect(wrapper.find('[data-testid="custom-breadcrumbs"]')).toBeTruthy());
+    expect(onBreadcrumbsChange).toHaveBeenLastCalledWith(null);
+  });
+
+  test('uses the outer App Layout slot when layouts are nested', async () => {
+    const externalContainer = document.createElement('div');
+    document.body.appendChild(externalContainer);
+    registerExternalContainer(externalContainer);
+
+    render(
+      <AppLayout
+        breadcrumbs={<BreadcrumbGroup items={[{ text: 'Outer', href: '/outer' }]} />}
+        content={
+          <AppLayout
+            navigationHide={true}
+            toolsHide={true}
+            breadcrumbs={<BreadcrumbGroup items={[{ text: 'Inner', href: '/inner' }]} />}
+          />
+        }
+      />
+    );
+
+    await waitFor(() => expect(externalContainer).toHaveTextContent('Outer'));
+    expect(externalContainer).not.toHaveTextContent('Inner');
+    expect(wrapper.findAllBreadcrumbGroups()).toHaveLength(0);
+    externalContainer.remove();
+  });
+
+  test('refuses a second external consumer', () => {
+    const first = widgetPlugins.registerBreadcrumbsConsumer({ onBreadcrumbsChange: jest.fn() });
+    const secondCallback = jest.fn();
+    const second = widgetPlugins.registerBreadcrumbsConsumer({ onBreadcrumbsChange: secondCallback });
+
+    expect(first.registered).toBe(true);
+    expect(second.registered).toBe(false);
+    expect(secondCallback).not.toHaveBeenCalled();
+
+    second.unregister();
+    expect(widgetPlugins.registerBreadcrumbsConsumer({ onBreadcrumbsChange: jest.fn() }).registered).toBe(false);
+
+    first.unregister();
+    expect(widgetPlugins.registerBreadcrumbsConsumer({ onBreadcrumbsChange: jest.fn() }).registered).toBe(true);
+  });
+});

--- a/src/app-layout/visual-refresh-toolbar/state/props-merger.ts
+++ b/src/app-layout/visual-refresh-toolbar/state/props-merger.ts
@@ -90,7 +90,7 @@ export const mergeProps: MergeProps = (ownProps, additionalProps) => {
 export const getPropsToMerge = (props: AppLayoutInternalProps, appLayoutState: AppLayoutPendingState): SharedProps => {
   const state = appLayoutState.widgetizedState;
   return {
-    breadcrumbs: props.breadcrumbs,
+    breadcrumbs: state ? state.breadcrumbs : props.breadcrumbs,
     ariaLabels: state ? state.ariaLabels : props.ariaLabels,
     navigation: !props.navigationTriggerHide && !props.navigationHide,
     navigationOpen: state ? state.navigationOpen : props.navigationOpen,

--- a/src/app-layout/visual-refresh-toolbar/state/use-app-layout.tsx
+++ b/src/app-layout/visual-refresh-toolbar/state/use-app-layout.tsx
@@ -10,7 +10,6 @@ import { useControllable } from '../../../internal/hooks/use-controllable';
 import { useIntersectionObserver } from '../../../internal/hooks/use-intersection-observer';
 import { useMobile } from '../../../internal/hooks/use-mobile';
 import { metrics } from '../../../internal/metrics';
-import { useGetGlobalBreadcrumbs } from '../../../internal/plugins/helpers/use-global-breadcrumbs';
 import { WidgetMessage } from '../../../internal/plugins/widget/interfaces';
 import globalVars from '../../../internal/styles/global-vars';
 import { getSplitPanelDefaultSize } from '../../../split-panel/utils/size-utils';
@@ -30,6 +29,7 @@ import { AppLayoutState } from '../interfaces';
 import { AppLayoutInternalProps, AppLayoutInternals } from '../interfaces';
 import { useAiDrawer } from './use-ai-drawer';
 import { useBottomDrawers } from './use-bottom-drawers';
+import { useBreadcrumbs } from './use-breadcrumbs';
 import { useFeatureNotifications } from './use-feature-notifications';
 import { useWidgetMessages } from './use-widget-messages';
 
@@ -436,7 +436,11 @@ export const useAppLayout = (
 
   const rootRef = useMergeRefs(rootRefInternal, intersectionObserverRef, onMountRootRef);
 
-  const discoveredBreadcrumbs = useGetGlobalBreadcrumbs(hasToolbar && !breadcrumbs);
+  const { breadcrumbs: resolvedBreadcrumbs, discoveredBreadcrumbs } = useBreadcrumbs({
+    hasToolbar,
+    isVisible: isIntersecting,
+    ownBreadcrumbs: breadcrumbs,
+  });
 
   useGlobalScrollPadding(verticalOffsets.header ?? 0);
 
@@ -458,7 +462,7 @@ export const useAppLayout = (
     ariaLabels: ariaLabelsWithDrawers,
     headerVariant,
     isMobile,
-    breadcrumbs,
+    breadcrumbs: resolvedBreadcrumbs,
     discoveredBreadcrumbs,
     stickyNotifications: resolvedStickyNotifications,
     navigationOpen: resolvedNavigationOpen,

--- a/src/app-layout/visual-refresh-toolbar/state/use-breadcrumbs.ts
+++ b/src/app-layout/visual-refresh-toolbar/state/use-breadcrumbs.ts
@@ -1,0 +1,125 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
+import { awsuiPluginsInternal } from '../../../internal/plugins/api';
+import { BreadcrumbsGlobalRegistration } from '../../../internal/plugins/controllers/breadcrumbs';
+import {
+  BreadcrumbsConsumer,
+  getBreadcrumbsConsumer,
+  subscribeBreadcrumbsConsumer,
+} from '../../../internal/plugins/widget/core';
+
+interface UseBreadcrumbsProps {
+  hasToolbar: boolean;
+  isVisible: boolean;
+  ownBreadcrumbs: React.ReactNode;
+}
+
+function getComponentName(type: React.ReactElement['type']) {
+  if (typeof type === 'string') {
+    return type;
+  }
+  const component = type as { displayName?: string; name?: string };
+  return component.displayName ?? component.name;
+}
+
+function extractBreadcrumbGroupProps(node: React.ReactNode): BreadcrumbGroupProps | null {
+  let result: BreadcrumbGroupProps | null = null;
+
+  React.Children.forEach(node, child => {
+    if (result || !React.isValidElement(child)) {
+      return;
+    }
+
+    if (child.type === React.Fragment) {
+      result = extractBreadcrumbGroupProps(child.props.children);
+      return;
+    }
+
+    const props = child.props as Partial<BreadcrumbGroupProps>;
+    if (getComponentName(child.type) !== 'BreadcrumbGroup' && !Array.isArray(props.items)) {
+      return;
+    }
+
+    const { items = [], ariaLabel, expandAriaLabel, onClick, onFollow } = props;
+    result = { items, ariaLabel, expandAriaLabel, onClick, onFollow };
+  });
+
+  return result;
+}
+
+function useBreadcrumbsConsumer() {
+  const [consumer, setConsumer] = useState<BreadcrumbsConsumer | undefined>(() => getBreadcrumbsConsumer());
+
+  useEffect(() => {
+    setConsumer(getBreadcrumbsConsumer());
+    return subscribeBreadcrumbsConsumer(setConsumer);
+  }, []);
+
+  return consumer;
+}
+
+export function useBreadcrumbs({ hasToolbar, isVisible, ownBreadcrumbs }: UseBreadcrumbsProps) {
+  const consumer = useBreadcrumbsConsumer();
+  const consumerRef = useRef(consumer);
+  consumerRef.current = consumer;
+
+  const ownBreadcrumbsProps = useMemo(() => extractBreadcrumbGroupProps(ownBreadcrumbs), [ownBreadcrumbs]);
+  const ownBreadcrumbsPropsRef = useRef(ownBreadcrumbsProps);
+  ownBreadcrumbsPropsRef.current = ownBreadcrumbsProps;
+  const hasOwnBreadcrumbsProps = !!ownBreadcrumbsProps;
+  const canRenderExternally = !ownBreadcrumbs || !!ownBreadcrumbsProps;
+  const isExternallyOwned = !!consumer && hasToolbar && canRenderExternally;
+  const shouldRegisterAppLayout = hasToolbar && isVisible && (!ownBreadcrumbs || isExternallyOwned);
+  const [discoveredBreadcrumbs, setDiscoveredBreadcrumbs] = useState<BreadcrumbGroupProps | null>(null);
+
+  useEffect(() => {
+    if (!shouldRegisterAppLayout) {
+      setDiscoveredBreadcrumbs(null);
+      return;
+    }
+
+    const unregister = awsuiPluginsInternal.breadcrumbs.registerAppLayout(breadcrumbs => {
+      setDiscoveredBreadcrumbs(breadcrumbs);
+      consumerRef.current?.onBreadcrumbsChange(breadcrumbs);
+    });
+
+    return () => {
+      unregister?.();
+      setDiscoveredBreadcrumbs(null);
+    };
+  }, [shouldRegisterAppLayout]);
+
+  const ownRegistrationRef = useRef<BreadcrumbsGlobalRegistration<BreadcrumbGroupProps> | null>(null);
+  useEffect(() => {
+    if (!consumer || !hasToolbar || !ownBreadcrumbsPropsRef.current || !isVisible) {
+      return;
+    }
+
+    const registration = awsuiPluginsInternal.breadcrumbs.registerBreadcrumbs(ownBreadcrumbsPropsRef.current, () => {});
+    ownRegistrationRef.current = registration;
+    return () => {
+      ownRegistrationRef.current = null;
+      registration.cleanup();
+    };
+  }, [consumer, hasOwnBreadcrumbsProps, hasToolbar, isVisible]);
+
+  useLayoutEffect(() => {
+    if (ownBreadcrumbsProps) {
+      ownRegistrationRef.current?.update(ownBreadcrumbsProps);
+    }
+  }, [ownBreadcrumbsProps]);
+
+  useLayoutEffect(() => {
+    if (consumer && hasToolbar && isVisible) {
+      consumer.onBreadcrumbsChange(canRenderExternally ? discoveredBreadcrumbs : null);
+    }
+  }, [canRenderExternally, consumer, discoveredBreadcrumbs, hasToolbar, isVisible]);
+
+  return {
+    breadcrumbs: isExternallyOwned ? null : ownBreadcrumbs,
+    discoveredBreadcrumbs: isExternallyOwned ? null : discoveredBreadcrumbs,
+  };
+}

--- a/src/internal/plugins/widget.ts
+++ b/src/internal/plugins/widget.ts
@@ -9,4 +9,5 @@ export {
   updateDrawer,
   showFeaturePromptIfPossible,
   clearFeatureNotifications,
+  registerBreadcrumbsConsumer,
 } from './widget/index';

--- a/src/internal/plugins/widget/core.ts
+++ b/src/internal/plugins/widget/core.ts
@@ -2,16 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { reportRuntimeApiWarning } from '../helpers/metrics';
-import { InitialMessage, WidgetMessage } from './interfaces';
+import { BreadcrumbsConsumerPayload, InitialMessage, WidgetMessage } from './interfaces';
 
 const storageKeyMessageHandler = Symbol.for('awsui-widget-api-message-handler');
 const storageKeyInitialMessages = Symbol.for('awsui-widget-api-initial-messages');
 const storageKeyReadyDeferCallbacks = Symbol.for('awsui-widget-api-ready-defer');
+const storageKeyBreadcrumbsConsumer = Symbol.for('awsui-widget-api-breadcrumbs-consumer');
+const storageKeyBreadcrumbsConsumerListeners = Symbol.for('awsui-widget-api-breadcrumbs-consumer-listeners');
+
+export interface BreadcrumbsConsumer extends BreadcrumbsConsumerPayload {
+  token: object;
+}
 
 interface WindowWithApi extends Window {
   [storageKeyMessageHandler]: MessageHandler | undefined;
   [storageKeyInitialMessages]: Array<InitialMessage<unknown>> | undefined;
   [storageKeyReadyDeferCallbacks]: Array<(value?: unknown) => void> | undefined;
+  [storageKeyBreadcrumbsConsumer]: BreadcrumbsConsumer | undefined;
+  [storageKeyBreadcrumbsConsumerListeners]: Set<(consumer: BreadcrumbsConsumer | undefined) => void> | undefined;
 }
 
 const oneTimeMessageTypes = ['emit-notification'];
@@ -61,6 +69,35 @@ export function registerAppLayoutHandler(handler: MessageHandler) {
 
 export function clearInitialMessages() {
   getWindow()[storageKeyInitialMessages] = undefined;
+}
+
+export function getBreadcrumbsConsumer() {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+  return getWindow()[storageKeyBreadcrumbsConsumer];
+}
+
+export function setBreadcrumbsConsumer(consumer: BreadcrumbsConsumer | undefined) {
+  const win = getWindow();
+  win[storageKeyBreadcrumbsConsumer] = consumer;
+  win[storageKeyBreadcrumbsConsumerListeners]?.forEach(listener => listener(consumer));
+}
+
+export function subscribeBreadcrumbsConsumer(listener: (consumer: BreadcrumbsConsumer | undefined) => void) {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+  const win = getWindow();
+  win[storageKeyBreadcrumbsConsumerListeners] ??= new Set();
+  win[storageKeyBreadcrumbsConsumerListeners].add(listener);
+  return () => {
+    win[storageKeyBreadcrumbsConsumerListeners]?.delete(listener);
+  };
+}
+
+export function clearBreadcrumbsConsumer() {
+  setBreadcrumbsConsumer(undefined);
 }
 
 /**

--- a/src/internal/plugins/widget/core.ts
+++ b/src/internal/plugins/widget/core.ts
@@ -30,6 +30,20 @@ function getWindow() {
   return window as Window as WindowWithApi;
 }
 
+function getBreadcrumbsRegistryWindow(currentWindow = getWindow()): WindowWithApi {
+  try {
+    const parentWindow = currentWindow.parent as WindowWithApi;
+    if (parentWindow === currentWindow) {
+      return currentWindow;
+    }
+    // Accessing custom properties verifies that the parent is same-origin.
+    void parentWindow[storageKeyBreadcrumbsConsumer];
+    return getBreadcrumbsRegistryWindow(parentWindow);
+  } catch {
+    return currentWindow;
+  }
+}
+
 export function getAppLayoutMessageHandler() {
   const win = getWindow();
   return win[storageKeyMessageHandler];
@@ -75,11 +89,11 @@ export function getBreadcrumbsConsumer() {
   if (typeof window === 'undefined') {
     return undefined;
   }
-  return getWindow()[storageKeyBreadcrumbsConsumer];
+  return getBreadcrumbsRegistryWindow()[storageKeyBreadcrumbsConsumer];
 }
 
 export function setBreadcrumbsConsumer(consumer: BreadcrumbsConsumer | undefined) {
-  const win = getWindow();
+  const win = getBreadcrumbsRegistryWindow();
   win[storageKeyBreadcrumbsConsumer] = consumer;
   win[storageKeyBreadcrumbsConsumerListeners]?.forEach(listener => listener(consumer));
 }
@@ -88,7 +102,7 @@ export function subscribeBreadcrumbsConsumer(listener: (consumer: BreadcrumbsCon
   if (typeof window === 'undefined') {
     return () => {};
   }
-  const win = getWindow();
+  const win = getBreadcrumbsRegistryWindow();
   win[storageKeyBreadcrumbsConsumerListeners] ??= new Set();
   win[storageKeyBreadcrumbsConsumerListeners].add(listener);
   return () => {

--- a/src/internal/plugins/widget/index.ts
+++ b/src/internal/plugins/widget/index.ts
@@ -2,9 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getExternalProps } from '../../utils/external-props';
-import { getAppLayoutInitialMessages, getAppLayoutMessageHandler, pushInitialMessage, setInitialMessage } from './core';
+import { reportRuntimeApiWarning } from '../helpers/metrics';
+import {
+  getAppLayoutInitialMessages,
+  getAppLayoutMessageHandler,
+  getBreadcrumbsConsumer,
+  pushInitialMessage,
+  setBreadcrumbsConsumer,
+  setInitialMessage,
+} from './core';
 import {
   AppLayoutUpdateMessage,
+  BreadcrumbsConsumerPayload,
+  BreadcrumbsConsumerRegistration,
   DrawerPayload,
   FeatureNotificationsPayload,
   FeatureNotificationsPayloadPublic,
@@ -55,6 +65,32 @@ export function showFeaturePromptIfPossible() {
 
 export function clearFeatureNotifications() {
   updateDrawer({ type: 'clearFeatureNotifications' });
+}
+
+/**
+ * Registers the surface that renders breadcrumbs outside App Layout.
+ */
+export function registerBreadcrumbsConsumer(payload: BreadcrumbsConsumerPayload): BreadcrumbsConsumerRegistration {
+  if (getBreadcrumbsConsumer()) {
+    reportRuntimeApiWarning(
+      'breadcrumbs',
+      'A breadcrumbs consumer is already registered. This registration is ignored.'
+    );
+    return { registered: false, unregister: () => {} };
+  }
+
+  const consumer = { ...payload, token: {} };
+  setBreadcrumbsConsumer(consumer);
+  payload.onBreadcrumbsChange(null);
+
+  return {
+    registered: true,
+    unregister: () => {
+      if (getBreadcrumbsConsumer()?.token === consumer.token) {
+        setBreadcrumbsConsumer(undefined);
+      }
+    },
+  };
 }
 
 /**

--- a/src/internal/plugins/widget/interfaces.ts
+++ b/src/internal/plugins/widget/interfaces.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import type { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
 import { ButtonGroupProps, ItemRuntime } from '../../../button-group/interfaces';
 import { NonCancelableEventHandler } from '../../../types/events';
 
@@ -189,6 +190,23 @@ export type FeatureNotificationsPayloadPublic<T> = Omit<
   FeatureNotificationsPayload<T>,
   '__persistFeatureNotifications' | '__retrieveFeatureNotifications'
 >;
+
+export interface BreadcrumbsConsumerPayload {
+  /**
+   * Receives the current breadcrumbs, or `null` when there are none, and is called again whenever they change.
+   * When rendering Cloudscape's BreadcrumbGroup from this value, set its internal `__disableGlobalization` prop
+   * to prevent the consumer's copy from publishing itself again.
+   */
+  onBreadcrumbsChange: (breadcrumbs: BreadcrumbGroupProps | null) => void;
+}
+
+export interface BreadcrumbsConsumerRegistration {
+  /**
+   * False when another consumer already owns external breadcrumbs rendering.
+   */
+  registered: boolean;
+  unregister: () => void;
+}
 
 export type RegisterDrawerMessage = Message<'registerLeftDrawer' | 'registerBottomDrawer', DrawerPayload>;
 export type RegisterFeatureNotificationsMessage<T> = Message<


### PR DESCRIPTION
### Description

Adds a widget API consumer channel that allows Global Navigation or another external container to render App Layout breadcrumbs without requiring console teams to update their bundled App Layout or BreadcrumbGroup components.

`registerBreadcrumbsConsumer` receives slot-based and discovered breadcrumb updates, preserves the producing BreadcrumbGroup handlers, and makes App Layout yield rendering while the consumer is registered. Unregistering the consumer restores rendering in App Layout. The consumer registry is shared through the highest accessible same-origin window so separate console roots can use one consumer.

A console bootstrap script can reserve ownership before Global Navigation registers by setting:

```js
window[Symbol.for('awsui-widget-api-external-owned-breadcrumbs')] = true;
```

This prevents the widgetized App Layout toolbar from rendering breadcrumbs during late consumer loading. The reservation remains active until the script clears the boolean. If the App Layout widget itself loads asynchronously, the console-bundled pre-widget skeleton can still render breadcrumbs until the widget becomes active.

The runtime implementation is contained in widget-delivered App Layout and internal widget files. Five development pages cover late consumer loading, startup reservation, multiple App Layouts, separate iframe roots, and router-style hidden iframe instances.

Related links, issue #, if available: n/a

### How has this been tested?

- Added focused unit coverage for slot and discovered breadcrumbs, updates, event handlers, late registration, startup reservation, custom slot content, nested layouts, duplicate consumers, and same-origin frame sharing.
- Added seven browser integration cases covering consumer ownership transfer, producer updates, startup reservation, multiple layouts, iframe roots, hidden mounted layouts, and restoration after consumer removal.
- Ran focused unit suites: 32 tests passed.
- Ran App Layout SSR suite: 5 tests passed.
- Ran the browser integration suite: 7 tests passed.
- Ran ESLint and `git diff --check`.
- Ran `npm run quick-build` and `npm run build`.
- Production size limits passed; the widget bundle remains 1.43 MB against the 1.45 MB limit.

Reviewers can use these pages with `?visualRefresh=true&appLayoutToolbar=true`:

- `app-layout/global-nav-breadcrumbs`
- `app-layout/global-nav-breadcrumbs-reserved`
- `app-layout/global-nav-breadcrumbs-multi-layout`
- `app-layout/global-nav-breadcrumbs-multi-instance`
- `app-layout/global-nav-breadcrumbs-hidden-instances-iframe`

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through the [checkSafeUrl function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
