### PR TITLE
feat: Add selector-based full base theme generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/test-utils/dom/index.ts
 src/test-utils/selectors
 src/icon/generated
 src/internal/generated/custom-css-properties
+pages/app/generated
 vendor/generated-*.txt
 # IDEs
 .vscode

--- a/build-tools/tasks/styles.js
+++ b/build-tools/tasks/styles.js
@@ -4,7 +4,9 @@
 /* eslint-disable no-unsanitized/method */
 
 const { parallel, series } = require('gulp');
-const { join } = require('path');
+const { promises: fs } = require('fs');
+const { dirname, join } = require('path');
+const { generateThemeStylesheet } = require('@cloudscape-design/theming-build');
 const { buildThemedComponentsInternal } = require('@cloudscape-design/theming-build/internal');
 
 const themes = require('../utils/themes');
@@ -70,4 +72,55 @@ function stylesTask(theme) {
   });
 }
 
-module.exports = series(compileStyleDictionary(), parallel(themes.map(theme => stylesTask(theme))));
+/**
+ * Pregenerates a stylesheet for the core-update theme, consumed by the dev pages (see pages/app/index.tsx).
+ *
+ * The stylesheet is generated at build time (instead of calling the runtime theming API in the
+ * browser) because the dev pages' CSP (style-src 'self') blocks runtime-injected style nodes.
+ * It is scoped under the .awsui-core-update selector, so the dev pages can always bundle it and
+ * activate it by toggling the class on the body element.
+ */
+function coreNewPagesThemeTask() {
+  const outputPath = join(__dirname, '../../pages/app/generated/core-update-theme.css');
+  return task('styles:core-update-pages-theme', async () => {
+    const { default: theme } = await import(join(styleDictionaryRoot, 'core-update/index.js'));
+
+    // Only themeable tokens can be part of a theme override. The rest would be
+    // dropped by generateThemeStylesheet with a console warning for each token.
+    const { default: metadata } = await import(join(styleDictionaryRoot, 'core-update/metadata.js'));
+    const filterThemeable = tokens =>
+      Object.fromEntries(Object.entries(tokens).filter(([token]) => metadata[token]?.themeable));
+
+    const override = {
+      tokens: filterThemeable(theme.tokens),
+      contexts: Object.fromEntries(
+        Object.entries(theme.contexts).map(([contextId, context]) => [
+          contextId,
+          { tokens: filterThemeable(context.tokens) },
+        ])
+      ),
+      ...(theme.referenceTokens ? { referenceTokens: theme.referenceTokens } : {}),
+    };
+
+    const { preset } = require(
+      join(__dirname, '../../', workspace.targetPath, 'components/internal/generated/theming/index.cjs')
+    );
+
+    const stylesheet = generateThemeStylesheet({
+      override,
+      preset,
+      baseThemeId: 'visual-refresh',
+      // Not a special value, this selector is only used for the dev pages.
+      selector: '.awsui-core-update',
+    });
+
+    await fs.mkdir(dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, stylesheet + '\n');
+  });
+}
+
+module.exports = series(
+  compileStyleDictionary(),
+  parallel(themes.map(theme => stylesTask(theme))),
+  coreNewPagesThemeTask()
+);

--- a/pages/app/app-context.tsx
+++ b/pages/app/app-context.tsx
@@ -13,11 +13,15 @@ import { THEME } from '~components/internal/environment';
 export enum Theme {
   Default = 'default',
   OneTheme = 'one-theme',
+  // Applied through a pregenerated, scoped stylesheet. See pages/app/index.tsx and
+  // build-tools/tasks/styles.js.
+  CoreUpdate = 'core-update',
 }
 
 const themeClassNames: Record<Theme, string> = {
   [Theme.Default]: '',
   [Theme.OneTheme]: 'awsui-one-theme',
+  [Theme.CoreUpdate]: 'awsui-core-update',
 };
 
 export function applyThemeClass(activeTheme: Theme) {

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -17,6 +17,9 @@ import StrictModeWrapper from './components/strict-mode-wrapper';
 
 // import font-size reset and Ember font
 import '@cloudscape-design/global-styles/index.css';
+// core-update theme stylesheet, pregenerated at build time and scoped under .awsui-core-update
+// (the dev pages' CSP blocks runtime-injected style nodes, see build-tools/tasks/styles.js)
+import './generated/core-update-theme.css';
 // screenshot test overrides
 import styles from './styles.scss';
 
@@ -100,9 +103,12 @@ const { direction, visualRefresh, theme, appLayoutWidget, appLayoutToolbar, appL
   history.location.search
 );
 const oneTheme = theme === Theme.OneTheme;
+// core-update is an override on top of visual refresh, so it always requires the visual refresh base.
+const coreNew = theme === Theme.CoreUpdate;
+const effectiveVisualRefresh = (visualRefresh || coreNew) && !oneTheme;
 
 // The VR class needs to be set before any React rendering occurs.
-window[awsuiVisualRefreshFlag] = () => visualRefresh && !oneTheme;
+window[awsuiVisualRefreshFlag] = () => effectiveVisualRefresh;
 if (!window[awsuiGlobalFlagsSymbol]) {
   window[awsuiGlobalFlagsSymbol] = {};
 }
@@ -117,7 +123,7 @@ window[awsuiGlobalFlagsSymbol].oneTheme = oneTheme;
 // Apply the active theme's body class (extensible via the Theme enum).
 applyThemeClass(theme);
 // useRuntimeVisualRefresh() detects .awsui-visual-refresh on body and short-circuits before its Symbol fallback.
-document.body.classList.toggle('awsui-visual-refresh', visualRefresh && !oneTheme);
+document.body.classList.toggle('awsui-visual-refresh', effectiveVisualRefresh);
 
 // Apply the direction value to the HTML element dir attribute
 document.documentElement.setAttribute('dir', direction);

--- a/pages/theming/scoped-theme.json
+++ b/pages/theming/scoped-theme.json
@@ -1,0 +1,208 @@
+{
+  "tokens": {
+    "fontFamilyBase": "'Noto Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
+    "colorTextBodyDefault": { "light": "#0f141a", "dark": "#CCCCD1" },
+
+    "colorBorderButtonNormalDefault": { "light": "#1b232d", "dark": "#f3f3f7" },
+    "colorBorderButtonNormalHover": { "light": "#1b232d", "dark": "#F9F9FB" },
+    "colorBorderButtonNormalActive": { "light": "#1b232d", "dark": "#F9F9FB" },
+    "colorBackgroundButtonNormalDefault": { "light": "#FFFFFF", "dark": "#161d26" },
+    "colorBackgroundButtonNormalHover": { "light": "#F6F6F9", "dark": "#424650" },
+    "colorBackgroundButtonNormalActive": { "light": "#EBEBF0", "dark": "#131920" },
+    "colorTextButtonNormalDefault": { "light": "#1b232d", "dark": "#f3f3f7" },
+    "colorTextButtonNormalHover": { "light": "#1b232d", "dark": "#F9F9FB" },
+    "colorTextButtonNormalActive": { "light": "#1b232d", "dark": "#F9F9FB" },
+
+    "colorBackgroundButtonPrimaryDefault": { "light": "#1b232d", "dark": "#F9F9FB" },
+    "colorBackgroundButtonPrimaryHover": { "light": "#06080A", "dark": "#FFFFFF" },
+    "colorBackgroundButtonPrimaryActive": { "light": "#1b232d", "dark": "#F9F9FB" },
+    "colorTextButtonPrimaryDefault": { "light": "#ffffff", "dark": "#131920" },
+    "colorTextButtonPrimaryHover": { "light": "#ffffff", "dark": "#131920" },
+    "colorTextButtonPrimaryActive": { "light": "#ffffff", "dark": "#131920" },
+
+    "colorBackgroundButtonLinkDefault": { "light": "#f6f6f9", "dark": "#232b37" },
+    "colorBackgroundButtonLinkHover": { "light": "#ebebf0", "dark": "#424650" },
+    "colorBackgroundButtonLinkActive": { "light": "#EBEBF0", "dark": "#131920" },
+    "colorTextLinkButtonNormalDefault": { "light": "#1b232d", "dark": "#F9F9FB" },
+
+    "colorBackgroundToggleButtonNormalPressed": { "light": "#EBEBF0", "dark": "#131920" }, 
+    "colorBorderToggleButtonNormalPressed": { "light": "#1b232d", "dark": "#F9F9FB" },
+    "colorTextToggleButtonNormalPressed": { "light": "#1b232d", "dark": "#F9F9FB" },
+
+    "colorBackgroundControlChecked": { "light": "#1b232d", "dark": "#F9F9FB" },
+
+    "colorTextLinkDefault": { "light": "#0f141a", "dark": "#CCCCD1" },
+    "colorTextLinkHover": { "light": "#424650", "dark": "#FFFFFF" },
+    "colorTextLinkSecondaryDefault": { "light": "#295eff", "dark": "#7598ff" },
+    "colorTextLinkSecondaryHover": { "light": "#0033CC", "dark": "#94AFFF" },
+    "colorTextLinkInfoDefault": { "light": "#295eff", "dark": "#7598ff" },
+    "colorTextLinkInfoHover": { "light": "#0033CC", "dark": "#94AFFF" },
+    "colorTextAccent": { "light": "#1b232d", "dark": "#F9F9FB" },
+
+    "colorBorderItemFocused": { "light": "#1b232d", "dark": "#F9F9FB" },
+    "colorBorderItemSelected": { "light": "#1b232d", "dark": "#F9F9FB" },
+    "colorBackgroundItemSelected": { "light": "#F6F6F9", "dark": "#0F141A" },
+    "colorBackgroundLayoutToggleSelectedDefault": { "light": "#1b232d", "dark": "#F9F9FB" },
+
+    "colorBackgroundSegmentActive": { "light": "#1b232d", "dark": "#F9F9FB" },
+
+    "colorBackgroundSliderRangeDefault": { "light": "#1b232d", "dark": "#F9F9FB" },
+    "colorBackgroundSliderHandleDefault": { "light": "#1b232d", "dark": "#F9F9FB" },
+
+    "colorBackgroundProgressBarValueDefault": { "light": "#1b232d", "dark": "#F9F9FB" },
+
+    "colorBackgroundNotificationGreen": { "light": "#008559", "dark": "#008559" },
+    "colorBackgroundNotificationBlue": { "light": "#0033CC", "dark": "#0033CC" },
+    "colorTextNotificationDefault": { "light": "#ffffff", "dark": "#ffffff" },
+
+    "colorTextStatusInfo": { "light": "#0033CC", "dark": "#7598FF" },
+    "colorTextStatusSuccess": { "light": "#006B48", "dark": "#00BD6B" },
+    "colorTextDropdownItemFilterMatch": { "light": "#1b232d", "dark": "#F9F9FB" },
+    "colorBackgroundDropdownItemFilterMatch": { "light": "#F3F3F7", "dark": "#06080A" },
+
+    "colorTextBreadcrumbCurrent": { "light": "#656871", "dark": "#8c8c94" },
+
+    "fontSizeHeadingXl": "24px",
+    "lineHeightHeadingXl": "30px",
+    "fontWeightHeadingXl": "600",
+
+    "fontSizeHeadingL": "20px",
+    "lineHeightHeadingL": "24px",
+    "fontWeightHeadingL": "600",
+
+    "fontSizeHeadingM": "18px",
+    "lineHeightHeadingM": "22px",
+    "fontWeightHeadingM": "600",
+
+    "fontSizeHeadingS": "16px",
+    "lineHeightHeadingS": "20px",
+    "fontWeightHeadingS": "600",
+
+    "fontSizeHeadingXs": "14px",
+    "lineHeightHeadingXs": "20px",
+    "fontWeightHeadingXs": "600",
+
+    "fontWeightButton": "600",
+    "fontWeightTabs": "600",
+    "fontSizeTabs": "16px",
+
+    "spaceAlertVertical": "4px",
+    "spaceButtonHorizontal": "12px",
+    "spaceTabsVertical": "2px",
+    "spaceTokenVertical": "2px",
+    "spaceFieldVertical": { "comfortable": "4px", "compact": "2px" },
+    "sizeVerticalInput": { "comfortable": "30px", "compact": "26px" },
+
+    "borderWidthButton": "1px",
+    "borderWidthToken": "1px",
+    "borderWidthAlert": "0px",
+    "borderItemWidth": "1px",
+    "borderWidthAlertInlineStart": "2px",
+    "borderWidthItemSelected": "1px",
+    "borderWidthCardSelected": "1px",
+
+    "borderRadiusAlert": "2px",
+    "borderRadiusBadge": "16px",
+    "borderRadiusButton": "8px",
+    "borderRadiusContainer": "12px",
+    "borderRadiusDropdown": "8px",
+    "borderRadiusDropzone": "8px",
+    "borderRadiusFlashbar": "4px",
+    "borderRadiusItem": "8px",
+    "borderRadiusInput": "8px",
+    "borderRadiusPopover": "8px",
+    "borderRadiusTabsFocusRing": "10px",
+    "borderRadiusToken": "8px",
+    "borderRadiusTutorialPanelItem": "4px",
+
+    "borderWidthIconSmall": "1.5px",
+    "borderWidthIconNormal": "1.5px",
+    "borderWidthIconMedium": "1.75px",
+    "borderWidthIconBig": "2px",
+    "borderWidthIconLarge": "2.5px"
+  },
+
+  "referenceTokens": {
+    "color": {
+      "primary": {
+        "seed": "#1b232d"
+      }
+    }
+  },
+
+  "contexts": {
+    "top-navigation": {
+      "tokens": {
+        "colorBackgroundContainerContent": { "light": "#ffffff", "dark": "#161d26" },
+        "colorBorderDividerDefault": { "light": "#c6c6cd", "dark": "#424650" },
+        "colorTextTopNavigationTitle": { "light": "#1b232d", "dark": "#f3f3f7" },
+        "colorTextInteractiveDefault": { "light": "#1b232d", "dark": "#f3f3f7" },
+        "colorTextInteractiveHover": { "light": "#1b232d", "dark": "#F9F9FB" },
+        "colorTextInteractiveActive": { "light": "#06080A", "dark": "#F6F6F9" },
+        "colorTextAccent": { "light": "#06080A", "dark": "#F6F6F9" },
+        "colorTextDropdownItemDefault": { "light": "#06080A", "dark": "#F6F6F9" },
+        "colorTextDropdownItemHighlighted": { "light": "#06080A", "dark": "#F6F6F9" },
+        "colorTextDropdown": { "light": "#06080A", "dark": "#F6F6F9" },
+        "colorTextGroupLabel": { "light": "#424650", "dark": "#c6c6cd" },
+        "colorBackgroundDropdownItemDefault": { "light": "#FFFFFF", "dark": "#1b232d" },
+        "colorBackgroundDropdownItemHover": { "light": "#f3f3f7", "dark": "#131920" },
+        "colorBorderDropdownContainer": { "light": "#b4b4bb", "dark": "#656871" },
+        "colorTextBodyDefault": { "light": "#06080A", "dark": "#F6F6F9" },
+        "colorBackgroundInputDefault": { "light": "#ffffff", "dark": "#1b232d" },
+        "colorBorderInputDefault": { "light": "#b4b4bb", "dark": "#656871" },
+        "colorTextInputDefault": { "light": "#06080A", "dark": "#F6F6F9" },
+        "colorTextInputPlaceholder": { "light": "#656871", "dark": "#8c8c94" },
+        "colorBorderDropdownItemDefault": { "light": "#e8e8e8", "dark": "#424650" },
+        "colorTextDropdownItemSecondary": { "light": "#424650", "dark": "#c6c6cd" },
+        "colorItemSelected": { "light": "#06080A", "dark": "#F6F6F9" },
+        "colorBackgroundDropdownItemSelected": { "light": "#F6F6F9", "dark": "#06080A" },
+        "colorBorderItemSelected": { "light": "#06080A", "dark": "#F6F6F9" },
+        "colorTextButtonInlineIconDefault": { "light": "#1b232d", "dark": "#F9F9FB" },
+        "colorTextButtonInlineIconHover": { "light": "#1b232d", "dark": "#F9F9FB" },
+        "colorTextHeadingDefault": { "light": "#06080A", "dark": "#F6F6F9" },
+        "colorBorderDropdownItemFocused": { "light": "#424650", "dark": "#dedee3" },
+        "colorBorderDropdownItemHover": { "light": "#8c8c94", "dark": "#656871" },
+        "colorBorderItemFocused": { "light": "#1b232dff", "dark": "#f9f9fbff" },
+        "colorBackgroundBadgeIcon": { "light": "#db0000", "dark": "#ff7a7a" }
+      }
+    },
+    "header": {
+      "tokens": {
+        "colorBorderButtonNormalDefault": "#f3f3f7",
+        "colorBorderButtonNormalHover": "#F9F9FB",
+        "colorBorderButtonNormalActive": "#F9F9FB",
+        "colorBackgroundButtonNormalHover": "#1B232D",
+        "colorBackgroundButtonNormalActive": "#131920",
+        "colorTextButtonNormalDefault": "#f3f3f7",
+        "colorTextButtonNormalHover": "#F9F9FB",
+        "colorTextButtonNormalActive": "#F9F9FB",
+        "colorBackgroundButtonPrimaryDefault": "#F9F9FB",
+        "colorBackgroundButtonPrimaryHover": "#FFFFFF",
+        "colorBackgroundButtonPrimaryActive": "#F9F9FB",
+        "colorTextButtonPrimaryDefault": "#131920",
+        "colorTextButtonPrimaryHover": "#131920",
+        "colorTextButtonPrimaryActive": "#131920",
+        "colorTextLinkDefault": "#CCCCD1"
+      }
+    },
+    "flashbar": {
+      "tokens": {
+        "colorBackgroundNotificationGreen": { "light": "#008559", "dark": "#008559" },
+        "colorBackgroundNotificationBlue": { "light": "#0033cc", "dark": "#0033cc" },
+        "colorTextNotificationDefault": { "light": "#ffffff", "dark": "#ffffff" }
+      }
+    },
+    "alert": {
+      "tokens": {
+        "colorBackgroundStatusInfo": { "light": "#f6f6f9", "dark": "#232b37" },
+        "colorBackgroundStatusWarning": { "light": "#f6f6f9", "dark": "#232b37" },
+        "colorBackgroundStatusError": { "light": "#f6f6f9", "dark": "#232b37" },
+        "colorBackgroundStatusSuccess": { "light": "#f6f6f9", "dark": "#232b37" },
+        "colorTextStatusInfo": { "light": "#0033CC", "dark": "#7598FF" },
+        "colorBorderStatusInfo": { "light": "#0033CC", "dark": "#7598FF" },
+        "colorTextStatusSuccess": { "light": "#006B48", "dark": "#00BD6B" },
+        "colorBorderStatusSuccess": { "light": "#006B48", "dark": "#00BD6B" }
+      }
+    }
+  }
+}

--- a/pages/theming/scoped-theme.page.tsx
+++ b/pages/theming/scoped-theme.page.tsx
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useRef, useState } from 'react';
+
+import { applyMode, Mode } from '@cloudscape-design/global-styles';
+
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Container,
+  Flashbar,
+  Header,
+  Link,
+  SpaceBetween,
+  StatusIndicator,
+} from '~components';
+import { applyTheme, Theme } from '~components/theming';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import scopedTheme from './scoped-theme.json';
+
+const SCOPE_CLASS = 'scoped-theme-demo';
+
+function DemoContent() {
+  return (
+    <SpaceBetween size="m">
+      <SpaceBetween direction="horizontal" size="s" alignItems="center">
+        <Button variant="primary">Primary button</Button>
+        <Button variant="normal">Secondary button</Button>
+        <Button variant="link">Tertiary button</Button>
+        <Link href="#">Learn more</Link>
+        <StatusIndicator type="success">Success</StatusIndicator>
+      </SpaceBetween>
+      <Flashbar
+        items={[
+          { type: 'success', header: 'Deployment succeeded', statusIconAriaLabel: 'success' },
+          { type: 'info', header: 'New version available', statusIconAriaLabel: 'info' },
+        ]}
+      />
+      <Alert type="info" header="Info alert">
+        Themed alert visual context.
+      </Alert>
+      <Alert type="success" header="Success alert">
+        Themed alert visual context.
+      </Alert>
+    </SpaceBetween>
+  );
+}
+
+export default function ScopedThemePage() {
+  const [themeEnabled, setThemeEnabled] = useState(true);
+  const [scopedDarkMode, setScopedDarkMode] = useState(false);
+  const scopeRef = useRef<HTMLDivElement>(null);
+
+  // Scoped runtime theming: the stylesheet is self-contained and applies only
+  // within elements matching the selector. The base theme (cascade layer)
+  // keeps supplying every token the theme does not define.
+  useEffect(() => {
+    if (!themeEnabled) {
+      setScopedDarkMode(false);
+      return;
+    }
+    const { reset } = applyTheme({ theme: scopedTheme as Theme, selector: `.${SCOPE_CLASS}` });
+    return reset;
+  }, [themeEnabled]);
+
+  // Modes compose on the scope element itself: applyMode must target the same
+  // element that carries the scope selector.
+  useEffect(() => {
+    if (scopeRef.current) {
+      applyMode(scopedDarkMode ? Mode.Dark : null, scopeRef.current);
+    }
+  }, [scopedDarkMode]);
+
+  return (
+    <Box padding="l">
+      <h1>Scoped theming (theming v2)</h1>
+      <SpaceBetween size="l">
+        <SpaceBetween direction="horizontal" size="l">
+          <Checkbox checked={themeEnabled} onChange={({ detail }) => setThemeEnabled(detail.checked)}>
+            Apply scoped theme
+          </Checkbox>
+          <Checkbox
+            checked={scopedDarkMode}
+            onChange={({ detail }) => setScopedDarkMode(detail.checked)}
+            disabled={!themeEnabled}
+          >
+            Dark mode inside scope
+          </Checkbox>
+        </SpaceBetween>
+        <ScreenshotArea>
+          <SpaceBetween size="l">
+            <Container header={<Header variant="h2">Outside scope — base theme</Header>}>
+              <DemoContent />
+            </Container>
+            <div ref={scopeRef} className={SCOPE_CLASS}>
+              <Container header={<Header variant="h2">Inside scope — custom theme</Header>}>
+                <DemoContent />
+              </Container>
+            </div>
+          </SpaceBetween>
+        </ScreenshotArea>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/pages/tsconfig.json
+++ b/pages/tsconfig.json
@@ -9,6 +9,7 @@
     "jsx": "react",
     "module": "esnext",
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "importHelpers": true,
     "strict": true,

--- a/src-themeable/__tests__/theming.test.ts
+++ b/src-themeable/__tests__/theming.test.ts
@@ -11,15 +11,19 @@ const preset = {
 
 jest.mock('@cloudscape-design/theming-build', () => ({
   buildThemedComponents: jest.fn().mockResolvedValue(undefined),
+  generateThemeStylesheet: jest.fn().mockReturnValue('.mock-stylesheet {}'),
 }));
 
 jest.mock('../internal/template/internal/generated/theming/index.cjs', () => ({
   preset,
 }));
 
-import { buildThemedComponents as themingCoreBuild } from '@cloudscape-design/theming-build';
+import {
+  buildThemedComponents as themingCoreBuild,
+  generateThemeStylesheet as themingCoreGenerateThemeStylesheet,
+} from '@cloudscape-design/theming-build';
 
-import { buildThemedComponents } from '../theming';
+import { buildThemedComponents, generateThemeStylesheet } from '../theming';
 
 describe('buildThemedComponents', () => {
   test('does not pass website token versions by default', async () => {
@@ -52,5 +56,20 @@ describe('buildThemedComponents', () => {
         },
       })
     );
+  });
+});
+
+describe('generateThemeStylesheet', () => {
+  test('passes the arguments through', () => {
+    const theme = { tokens: { borderRadiusButton: '8px' } } as any;
+
+    const stylesheet = generateThemeStylesheet({ theme, selector: '.my-theme' });
+
+    expect(stylesheet).toBe('.mock-stylesheet {}');
+    expect(themingCoreGenerateThemeStylesheet).toHaveBeenCalledWith({
+      override: theme,
+      preset,
+      selector: '.my-theme',
+    });
   });
 });

--- a/src-themeable/__tests__/theming.test.ts
+++ b/src-themeable/__tests__/theming.test.ts
@@ -70,6 +70,7 @@ describe('generateThemeStylesheet', () => {
       override: theme,
       preset,
       selector: '.my-theme',
+      baseThemeId: 'visual-refresh',
     });
   });
 });

--- a/src-themeable/theming.ts
+++ b/src-themeable/theming.ts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { join } from 'path';
 
-import { buildThemedComponents as themingCoreBuild } from '@cloudscape-design/theming-build';
+import {
+  buildThemedComponents as themingCoreBuild,
+  generateThemeStylesheet as themingCoreGenerateThemeStylesheet,
+} from '@cloudscape-design/theming-build';
 
 import { preset, TypedOverride } from './internal/template/internal/generated/theming/index.cjs';
 
@@ -10,6 +13,8 @@ const internalDir = join(__dirname, './internal');
 const scssDir = join(internalDir, './scss');
 const templateDir = join(internalDir, './template');
 const designTokensTemplateDir = join(internalDir, './template-tokens');
+
+const VISUAL_REFRESH_THEME_ID = 'visual-refresh';
 
 export type Theme = TypedOverride;
 export interface BuildThemedComponentsParams {
@@ -42,5 +47,21 @@ export function buildThemedComponents({
     templateDir,
     designTokensTemplateDir,
     scssDir,
+  });
+}
+
+export interface GenerateThemeStylesheetParams {
+  theme: Theme;
+  selector: string;
+}
+
+export function generateThemeStylesheet({ theme, selector }: GenerateThemeStylesheetParams): string {
+  return themingCoreGenerateThemeStylesheet({
+    override: theme,
+    selector,
+    preset,
+    // Current theming builder relies on tokens being relative to a base theme for
+    // all non-themeable tokens, which is currently visual refresh.
+    baseThemeId: VISUAL_REFRESH_THEME_ID,
   });
 }

--- a/src/theming/__tests__/index.test.ts
+++ b/src/theming/__tests__/index.test.ts
@@ -53,6 +53,21 @@ test('applyTheme appends and removes awsui style node', () => {
   expect(findStyleNode()).toBeNull();
 });
 
+test('applyTheme with selector generates a scoped, self-contained stylesheet', () => {
+  applyTheme({ theme, selector: '.my-scope' });
+
+  const styleNode = findStyleNode();
+  expect(styleNode!.textContent).toContain('.my-scope');
+  // Scoped stylesheets rely on the base theme cascade layer instead of specificity bumps.
+  expect(styleNode!.textContent).not.toContain(':not(#\\9)');
+});
+
+test('generateThemeStylesheet with selector scopes all rules to the selector', () => {
+  const stylesheet = generateThemeStylesheet({ theme, selector: '.my-scope' });
+  expect(stylesheet).toContain('.my-scope');
+  expect(stylesheet).not.toContain(':not(#\\9)');
+});
+
 test('applyTheme respects nonce meta elements', () => {
   const nonce = 'fgw4g5saf';
   attachNonceMetaElement(nonce);

--- a/src/theming/index.ts
+++ b/src/theming/index.ts
@@ -8,34 +8,40 @@ import {
 
 import { preset, TypedOverride } from '../internal/generated/theming';
 
+const VISUAL_REFRESH_THEME_ID = 'visual-refresh';
+
 export type Theme = TypedOverride;
 export interface ApplyThemeParams {
   theme: Theme;
   baseThemeId?: string;
+  selector?: string;
 }
 
 export interface ApplyThemeResult {
   reset: () => void;
 }
 
-export function applyTheme({ theme, baseThemeId }: ApplyThemeParams): ApplyThemeResult {
+export function applyTheme({ theme, baseThemeId, selector }: ApplyThemeParams): ApplyThemeResult {
   return coreApplyTheme({
     override: theme,
     preset,
-    baseThemeId,
+    selector,
+    baseThemeId: baseThemeId ?? (selector ? VISUAL_REFRESH_THEME_ID : undefined),
   });
 }
 
 export interface GenerateThemeStylesheetParams {
   theme: Theme;
   baseThemeId?: string;
+  selector?: string;
 }
 
-export function generateThemeStylesheet({ theme, baseThemeId }: GenerateThemeStylesheetParams): string {
+export function generateThemeStylesheet({ theme, baseThemeId, selector }: GenerateThemeStylesheetParams): string {
   return coreGenerateThemeStylesheet({
     override: theme,
     preset,
-    baseThemeId,
+    baseThemeId: baseThemeId ?? (selector ? VISUAL_REFRESH_THEME_ID : undefined),
+    selector,
   });
 }
 

--- a/style-dictionary/core-update/borders.ts
+++ b/style-dictionary/core-update/borders.ts
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
+import { StyleDictionary } from '../utils/interfaces.js';
+import { tokens as parentTokens } from '../visual-refresh/borders.js';
+
+// core-update border overrides; the full visual-refresh set (parentTokens) is the base.
+const tokens: StyleDictionary.BordersDictionary = {
+  borderWidthButton: '1px',
+  borderWidthToken: '1px',
+  borderWidthAlert: '0px',
+  borderItemWidth: '1px',
+  borderWidthAlertInlineStart: '2px',
+  borderWidthItemSelected: '1px',
+  borderWidthCardSelected: '1px',
+
+  borderRadiusAlert: '2px',
+  borderRadiusBadge: '16px',
+  borderRadiusButton: '8px',
+  borderRadiusContainer: '12px',
+  borderRadiusDropdown: '8px',
+  borderRadiusDropzone: '8px',
+  borderRadiusFlashbar: '4px',
+  borderRadiusItem: '8px',
+  borderRadiusInput: '8px',
+  borderRadiusPopover: '8px',
+  borderRadiusTabsFocusRing: '10px',
+  borderRadiusToken: '8px',
+  borderRadiusTutorialPanelItem: '4px',
+
+  borderWidthIconSmall: '1.5px',
+  borderWidthIconNormal: '1.5px',
+  borderWidthIconMedium: '1.75px',
+  borderWidthIconBig: '2px',
+  borderWidthIconLarge: '2.5px',
+};
+
+const expandedTokens: StyleDictionary.ExpandedGlobalScopeDictionary = merge({}, parentTokens, tokens);
+
+export { expandedTokens as tokens };

--- a/style-dictionary/core-update/color-palette.ts
+++ b/style-dictionary/core-update/color-palette.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ReferenceTokens } from '@cloudscape-design/theming-build';
+
+import { StyleDictionary } from '../utils/interfaces.js';
+import { referenceTokens as vrReferenceTokens, tokens as vrTokens } from '../visual-refresh/color-palette.js';
+
+const referenceTokens: ReferenceTokens = {
+  ...vrReferenceTokens,
+  color: {
+    ...vrReferenceTokens.color,
+    primary: { seed: '#1b232d' },
+  },
+};
+
+export const tokens = vrTokens;
+export const mode: StyleDictionary.ModeIdentifier = 'color';
+export { referenceTokens };

--- a/style-dictionary/core-update/colors.ts
+++ b/style-dictionary/core-update/colors.ts
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
+import { expandColorDictionary } from '../utils/index.js';
+import { StyleDictionary } from '../utils/interfaces.js';
+import { tokens as parentTokens } from '../visual-refresh/colors.js';
+
+// core-update color overrides; the full visual-refresh color set (parentTokens) is the base.
+const tokens: StyleDictionary.ColorsDictionary = {
+  colorTextBodyDefault: { light: '#0f141a', dark: '#ccccd1' },
+
+  colorBorderButtonNormalDefault: { light: '#1b232d', dark: '#f3f3f7' },
+  colorBorderButtonNormalHover: { light: '#1b232d', dark: '#f9f9fb' },
+  colorBorderButtonNormalActive: { light: '#1b232d', dark: '#f9f9fb' },
+  colorBackgroundButtonNormalDefault: { light: '#ffffff', dark: '#161d26' },
+  colorBackgroundButtonNormalHover: { light: '#f6f6f9', dark: '#424650' },
+  colorBackgroundButtonNormalActive: { light: '#ebebf0', dark: '#131920' },
+  colorTextButtonNormalDefault: { light: '#1b232d', dark: '#f3f3f7' },
+  colorTextButtonNormalHover: { light: '#1b232d', dark: '#f9f9fb' },
+  colorTextButtonNormalActive: { light: '#1b232d', dark: '#f9f9fb' },
+
+  colorBackgroundButtonPrimaryDefault: { light: '#1b232d', dark: '#f9f9fb' },
+  colorBackgroundButtonPrimaryHover: { light: '#06080a', dark: '#ffffff' },
+  colorBackgroundButtonPrimaryActive: { light: '#1b232d', dark: '#f9f9fb' },
+  colorTextButtonPrimaryDefault: { light: '#ffffff', dark: '#131920' },
+  colorTextButtonPrimaryHover: { light: '#ffffff', dark: '#131920' },
+  colorTextButtonPrimaryActive: { light: '#ffffff', dark: '#131920' },
+
+  colorBackgroundButtonLinkDefault: { light: '#f6f6f9', dark: '#232b37' },
+  colorBackgroundButtonLinkHover: { light: '#ebebf0', dark: '#424650' },
+  colorBackgroundButtonLinkActive: { light: '#ebebf0', dark: '#131920' },
+  colorTextLinkButtonNormalDefault: { light: '#1b232d', dark: '#f9f9fb' },
+
+  colorBackgroundToggleButtonNormalPressed: { light: '#ebebf0', dark: '#131920' },
+  colorBorderToggleButtonNormalPressed: { light: '#1b232d', dark: '#f9f9fb' },
+  colorTextToggleButtonNormalPressed: { light: '#1b232d', dark: '#f9f9fb' },
+
+  colorBackgroundControlChecked: { light: '#1b232d', dark: '#f9f9fb' },
+
+  colorTextLinkDefault: { light: '#0f141a', dark: '#ccccd1' },
+  colorTextLinkHover: { light: '#424650', dark: '#ffffff' },
+  colorTextLinkSecondaryDefault: { light: '#295eff', dark: '#7598ff' },
+  colorTextLinkSecondaryHover: { light: '#0033cc', dark: '#94afff' },
+  colorTextLinkInfoDefault: { light: '#295eff', dark: '#7598ff' },
+  colorTextLinkInfoHover: { light: '#0033cc', dark: '#94afff' },
+  colorTextAccent: { light: '#1b232d', dark: '#f9f9fb' },
+
+  colorBorderItemFocused: { light: '#1b232d', dark: '#f9f9fb' },
+  colorBorderItemSelected: { light: '#1b232d', dark: '#f9f9fb' },
+  colorBackgroundItemSelected: { light: '#f6f6f9', dark: '#0f141a' },
+  colorBackgroundLayoutToggleSelectedDefault: { light: '#1b232d', dark: '#f9f9fb' },
+
+  colorBackgroundSegmentActive: { light: '#1b232d', dark: '#f9f9fb' },
+
+  colorBackgroundSliderRangeDefault: { light: '#1b232d', dark: '#f9f9fb' },
+  colorBackgroundSliderHandleDefault: { light: '#1b232d', dark: '#f9f9fb' },
+
+  colorBackgroundProgressBarValueDefault: { light: '#1b232d', dark: '#f9f9fb' },
+
+  colorBackgroundNotificationGreen: { light: '#008559', dark: '#008559' },
+  colorBackgroundNotificationBlue: { light: '#0033cc', dark: '#0033cc' },
+  colorTextNotificationDefault: { light: '#ffffff', dark: '#ffffff' },
+
+  colorTextStatusInfo: { light: '#0033cc', dark: '#7598ff' },
+  colorTextStatusSuccess: { light: '#006b48', dark: '#00bd6b' },
+  colorTextDropdownItemFilterMatch: { light: '#1b232d', dark: '#f9f9fb' },
+  colorBackgroundDropdownItemFilterMatch: { light: '#f3f3f7', dark: '#06080a' },
+
+  colorTextBreadcrumbCurrent: { light: '#656871', dark: '#8c8c94' },
+};
+
+const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandColorDictionary(tokens)
+);
+
+export { expandedTokens as tokens };
+export const mode: StyleDictionary.ModeIdentifier = 'color';

--- a/style-dictionary/core-update/contexts/alert.ts
+++ b/style-dictionary/core-update/contexts/alert.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
+import { expandColorDictionary } from '../../utils/index.js';
+import { StyleDictionary } from '../../utils/interfaces.js';
+import { tokens as parentTokens } from '../../visual-refresh/contexts/alert.js';
+
+// core-update alert context overrides; the full visual-refresh context (parentTokens) is the base.
+const tokens: StyleDictionary.ColorsDictionary = {
+  colorBackgroundStatusInfo: { light: '#f6f6f9', dark: '#232b37' },
+  colorBackgroundStatusWarning: { light: '#f6f6f9', dark: '#232b37' },
+  colorBackgroundStatusError: { light: '#f6f6f9', dark: '#232b37' },
+  colorBackgroundStatusSuccess: { light: '#f6f6f9', dark: '#232b37' },
+  colorTextStatusInfo: { light: '#0033cc', dark: '#7598ff' },
+  colorBorderStatusInfo: { light: '#0033cc', dark: '#7598ff' },
+  colorTextStatusSuccess: { light: '#006b48', dark: '#00bd6b' },
+  colorBorderStatusSuccess: { light: '#006b48', dark: '#00bd6b' },
+};
+
+const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandColorDictionary(tokens)
+);
+
+export { expandedTokens as tokens };

--- a/style-dictionary/core-update/contexts/flashbar.ts
+++ b/style-dictionary/core-update/contexts/flashbar.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
+import { expandColorDictionary } from '../../utils/index.js';
+import { StyleDictionary } from '../../utils/interfaces.js';
+import { tokens as parentTokens } from '../../visual-refresh/contexts/flashbar.js';
+
+// core-update flashbar context overrides; the full visual-refresh context (parentTokens) is the base.
+const tokens: StyleDictionary.ColorsDictionary = {
+  colorBackgroundNotificationGreen: { light: '#008559', dark: '#008559' },
+  colorBackgroundNotificationBlue: { light: '#0033cc', dark: '#0033cc' },
+  colorTextNotificationDefault: { light: '#ffffff', dark: '#ffffff' },
+};
+
+const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandColorDictionary(tokens)
+);
+
+export { expandedTokens as tokens };

--- a/style-dictionary/core-update/contexts/header.ts
+++ b/style-dictionary/core-update/contexts/header.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
+import { expandColorDictionary } from '../../utils/index.js';
+import { StyleDictionary } from '../../utils/interfaces.js';
+import { tokens as parentTokens } from '../../visual-refresh/contexts/header.js';
+
+// core-update header context overrides; the full visual-refresh context (parentTokens) is the base.
+const tokens: StyleDictionary.ColorsDictionary = {
+  colorBorderButtonNormalDefault: '#f3f3f7',
+  colorBorderButtonNormalHover: '#f9f9fb',
+  colorBorderButtonNormalActive: '#f9f9fb',
+  colorBackgroundButtonNormalHover: '#1b232d',
+  colorBackgroundButtonNormalActive: '#131920',
+  colorTextButtonNormalDefault: '#f3f3f7',
+  colorTextButtonNormalHover: '#f9f9fb',
+  colorTextButtonNormalActive: '#f9f9fb',
+  colorBackgroundButtonPrimaryDefault: '#f9f9fb',
+  colorBackgroundButtonPrimaryHover: '#ffffff',
+  colorBackgroundButtonPrimaryActive: '#f9f9fb',
+  colorTextButtonPrimaryDefault: '#131920',
+  colorTextButtonPrimaryHover: '#131920',
+  colorTextButtonPrimaryActive: '#131920',
+  colorTextLinkDefault: '#ccccd1',
+};
+
+const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandColorDictionary(tokens)
+);
+
+export { expandedTokens as tokens };

--- a/style-dictionary/core-update/contexts/top-navigation.ts
+++ b/style-dictionary/core-update/contexts/top-navigation.ts
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
+import { expandColorDictionary } from '../../utils/index.js';
+import { StyleDictionary } from '../../utils/interfaces.js';
+import { tokens as parentTokens } from '../../visual-refresh/contexts/top-navigation.js';
+
+// core-update top-navigation context overrides; the full visual-refresh context (parentTokens) is the base.
+const tokens: StyleDictionary.ColorsDictionary = {
+  colorBackgroundContainerContent: { light: '#ffffff', dark: '#161d26' },
+  colorBorderDividerDefault: { light: '#c6c6cd', dark: '#424650' },
+  colorTextTopNavigationTitle: { light: '#1b232d', dark: '#f3f3f7' },
+  colorTextInteractiveDefault: { light: '#1b232d', dark: '#f3f3f7' },
+  colorTextInteractiveHover: { light: '#1b232d', dark: '#f9f9fb' },
+  colorTextInteractiveActive: { light: '#06080a', dark: '#f6f6f9' },
+  colorTextAccent: { light: '#06080a', dark: '#f6f6f9' },
+  colorTextDropdownItemDefault: { light: '#06080a', dark: '#f6f6f9' },
+  colorTextDropdownItemHighlighted: { light: '#06080a', dark: '#f6f6f9' },
+  colorTextGroupLabel: { light: '#424650', dark: '#c6c6cd' },
+  colorBackgroundDropdownItemDefault: { light: '#ffffff', dark: '#1b232d' },
+  colorBackgroundDropdownItemHover: { light: '#f3f3f7', dark: '#131920' },
+  colorBorderDropdownContainer: { light: '#b4b4bb', dark: '#656871' },
+  colorTextBodyDefault: { light: '#06080a', dark: '#f6f6f9' },
+  colorBackgroundInputDefault: { light: '#ffffff', dark: '#1b232d' },
+  colorBorderInputDefault: { light: '#b4b4bb', dark: '#656871' },
+  colorTextInputPlaceholder: { light: '#656871', dark: '#8c8c94' },
+  colorBorderDropdownItemDefault: { light: '#e8e8e8', dark: '#424650' },
+  colorTextDropdownItemSecondary: { light: '#424650', dark: '#c6c6cd' },
+  colorItemSelected: { light: '#06080a', dark: '#f6f6f9' },
+  colorBackgroundDropdownItemSelected: { light: '#f6f6f9', dark: '#06080a' },
+  colorBorderItemSelected: { light: '#06080a', dark: '#f6f6f9' },
+  colorTextButtonInlineIconDefault: { light: '#1b232d', dark: '#f9f9fb' },
+  colorTextButtonInlineIconHover: { light: '#1b232d', dark: '#f9f9fb' },
+  colorTextHeadingDefault: { light: '#06080a', dark: '#f6f6f9' },
+  colorBorderDropdownItemFocused: { light: '#424650', dark: '#dedee3' },
+  colorBorderDropdownItemHover: { light: '#8c8c94', dark: '#656871' },
+  colorBorderItemFocused: { light: '#1b232d', dark: '#f9f9fb' },
+  colorBackgroundBadgeIcon: { light: '#db0000', dark: '#ff7a7a' },
+};
+
+const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandColorDictionary(tokens)
+);
+
+export { expandedTokens as tokens };

--- a/style-dictionary/core-update/index.ts
+++ b/style-dictionary/core-update/index.ts
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ThemeBuilder } from '@cloudscape-design/theming-build';
+
+import {
+  createAlertContext,
+  createAppLayoutToolbarContext,
+  createCompactTableContext,
+  createFlashbarContext,
+  createFlashbarWarningContext,
+  createHeaderAlertContext,
+  createHeaderContext,
+  createTopNavigationContext,
+} from '../utils/contexts.js';
+import { StyleDictionary } from '../utils/interfaces.js';
+import { createColorMode, createDensityMode, createMotionMode } from '../utils/modes.js';
+
+const modes = [
+  createColorMode('.awsui-dark-mode'),
+  createDensityMode('.awsui-compact-mode'),
+  createMotionMode('.awsui-motion-disabled'),
+];
+
+// core-update is an override on top of visual-refresh. Each core-update category module
+// is self-contained: it merges the core-update overrides onto the visual-refresh base
+// and exports the complete category. Categories that core-update does not customize
+// (color-charts, color-severity, motion, shadows) are taken from visual-refresh
+// directly. color-palette comes first so the seeded primary reference tokens are
+// registered before any token resolves against them.
+const tokenCategories: Array<StyleDictionary.CategoryModule> = [
+  await import('./color-palette.js'),
+  await import('../visual-refresh/color-charts.js'),
+  await import('../visual-refresh/color-severity.js'),
+  await import('./colors.js'),
+  await import('./typography.js'),
+  await import('./borders.js'),
+  await import('../visual-refresh/motion.js'),
+  await import('../visual-refresh/shadows.js'),
+  await import('./sizes.js'),
+  await import('./spacing.js'),
+];
+
+const builder = new ThemeBuilder('core-update', 'body', modes);
+
+tokenCategories.forEach(({ tokens, mode: modeId, referenceTokens }) => {
+  const mode = modes.find(m => m.id === modeId);
+  if (referenceTokens) {
+    builder.addReferenceTokens(referenceTokens, mode);
+  }
+  builder.addTokens(tokens, mode);
+});
+
+// Contexts follow the same convention: core-update context modules merge their
+// overrides onto the visual-refresh context base; the others come from visual-refresh.
+builder.addContext(createCompactTableContext((await import('../visual-refresh/contexts/compact-table.js')).tokens));
+builder.addContext(createTopNavigationContext((await import('./contexts/top-navigation.js')).tokens));
+builder.addContext(createHeaderContext((await import('./contexts/header.js')).tokens));
+builder.addContext(
+  createAppLayoutToolbarContext((await import('../visual-refresh/contexts/app-layout-toolbar.js')).tokens)
+);
+
+const notificationContexts = [
+  createFlashbarContext((await import('./contexts/flashbar.js')).tokens),
+  createFlashbarWarningContext((await import('../visual-refresh/contexts/flashbar-warning.js')).tokens),
+  createAlertContext((await import('./contexts/alert.js')).tokens),
+  createHeaderAlertContext((await import('../visual-refresh/contexts/header-alert.js')).tokens),
+];
+notificationContexts.forEach(context => builder.addContext(context));
+
+const theme = builder.build();
+
+export default theme;

--- a/style-dictionary/core-update/metadata.ts
+++ b/style-dictionary/core-update/metadata.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import metadata from '../visual-refresh/metadata/index.js';
+
+export default metadata;

--- a/style-dictionary/core-update/sizes.ts
+++ b/style-dictionary/core-update/sizes.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
+import { expandDensityDictionary } from '../utils/index.js';
+import { StyleDictionary } from '../utils/interfaces.js';
+import { tokens as parentTokens } from '../visual-refresh/sizes.js';
+
+// core-update size overrides; the full visual-refresh set (parentTokens) is the base.
+const tokens: StyleDictionary.SizesDictionary = {
+  sizeVerticalInput: { comfortable: '30px', compact: '26px' },
+};
+
+const expandedTokens: StyleDictionary.ExpandedDensityScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandDensityDictionary(tokens)
+);
+
+export { expandedTokens as tokens };
+export const mode: StyleDictionary.ModeIdentifier = 'density';

--- a/style-dictionary/core-update/spacing.ts
+++ b/style-dictionary/core-update/spacing.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
+import { expandDensityDictionary } from '../utils/index.js';
+import { StyleDictionary } from '../utils/interfaces.js';
+import { tokens as parentTokens } from '../visual-refresh/spacing.js';
+
+// core-update spacing overrides; the full visual-refresh set (parentTokens) is the base.
+const tokens: StyleDictionary.SpacingDictionary = {
+  spaceAlertVertical: '4px',
+  spaceButtonHorizontal: '12px',
+  spaceTabsVertical: '2px',
+  spaceTokenVertical: '2px',
+  spaceFieldVertical: { comfortable: '4px', compact: '2px' },
+};
+
+const expandedTokens: StyleDictionary.ExpandedDensityScopeDictionary = merge(
+  {},
+  parentTokens,
+  expandDensityDictionary(tokens)
+);
+
+export { expandedTokens as tokens };
+export const mode: StyleDictionary.ModeIdentifier = 'density';

--- a/style-dictionary/core-update/typography.ts
+++ b/style-dictionary/core-update/typography.ts
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge.js';
+
+import { StyleDictionary } from '../utils/interfaces.js';
+import { tokens as parentTokens } from '../visual-refresh/typography.js';
+
+// core-update typography overrides; the full visual-refresh set (parentTokens) is the base.
+const tokens: StyleDictionary.TypographyDictionary = {
+  fontFamilyBase: "'Noto Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
+
+  fontSizeHeadingXl: '24px',
+  lineHeightHeadingXl: '30px',
+  fontWeightHeadingXl: '600',
+
+  fontSizeHeadingL: '20px',
+  lineHeightHeadingL: '24px',
+  fontWeightHeadingL: '600',
+
+  fontSizeHeadingM: '18px',
+  lineHeightHeadingM: '22px',
+  fontWeightHeadingM: '600',
+
+  fontSizeHeadingS: '16px',
+  lineHeightHeadingS: '20px',
+  fontWeightHeadingS: '600',
+
+  fontSizeHeadingXs: '14px',
+  lineHeightHeadingXs: '20px',
+  fontWeightHeadingXs: '600',
+
+  fontWeightButton: '600',
+  fontWeightTabs: '600',
+  fontSizeTabs: '16px',
+};
+
+const expandedTokens: StyleDictionary.ExpandedGlobalScopeDictionary = merge({}, parentTokens, tokens);
+
+export { expandedTokens as tokens };


### PR DESCRIPTION
### Description

Developer-facing integration of https://github.com/cloudscape-design/theming-core/pull/208. ~~Tests will fail until that PR is merged, but this is still reviewable.~~ Now passing, ready ro review!

### How has this been tested?

Tested locally. This also adds the new theme to the dev pages (add `?theme=core-update` to the url).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
