### PR TITLE
chore: Add workflow concurrency cancellation

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -18,8 +18,8 @@ permissions:
   security-events: write
 
 # Cancel superseded runs for the same ref to free shared runner capacity.
-# The condition keeps cancellation limited to pull_request events, so runs on
-# main (push) and in the merge queue (merge_group) are never cancelled.
+# Only cancel PR runs; other events get a unique group so their runs never
+# cancel or drop each other.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -17,6 +17,13 @@ permissions:
   contents: read
   security-events: write
 
+# Cancel superseded runs for the same ref to free shared runner capacity.
+# The condition keeps cancellation limited to pull_request events, so runs on
+# main (push) and in the merge queue (merge_group) are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: build${{ matrix.react != 16 && format(' (React {0})', matrix.react) || '' }}

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -21,7 +21,7 @@ permissions:
 # The condition keeps cancellation limited to pull_request events, so runs on
 # main (push) and in the merge queue (merge_group) are never cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -6,8 +6,7 @@ on:
       - main
 
 # Cancel superseded runs for the same ref to free shared runner capacity.
-# The condition keeps cancellation limited to pull_request events, so a run is
-# never cancelled on main or in a merge queue.
+# Only cancel PR runs; other events keep their runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
 
+# Cancel superseded runs for the same ref to free shared runner capacity.
+# The condition keeps cancellation limited to pull_request events, so a run is
+# never cancelled on main or in a merge queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # This workflow runs untrusted PR code (npm install + build) and therefore
 # requests no write permissions. Fork PRs would have their token downgraded to
 # read-only anyway. Posting the commit status is delegated to the separate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
 
+# Cancel superseded runs for the same ref to free shared runner capacity.
+# The condition keeps cancellation limited to pull_request events, so a run is
+# never cancelled on main or in a merge queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   id-token: write
   actions: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,7 @@ on:
       - main
 
 # Cancel superseded runs for the same ref to free shared runner capacity.
-# The condition keeps cancellation limited to pull_request events, so a run is
-# never cancelled on main or in a merge queue.
+# Only cancel PR runs; other events keep their runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -14,7 +14,7 @@ on:
 # The condition keeps cancellation limited to pull_request events, so
 # merge_group and workflow_dispatch runs are never cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -10,6 +10,13 @@ on:
     branches:
       - main
 
+# Cancel superseded runs for the same ref to free shared runner capacity.
+# The condition keeps cancellation limited to pull_request events, so
+# merge_group and workflow_dispatch runs are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   dry-run:
     uses: cloudscape-design/actions/.github/workflows/dry-run.yml@main

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -11,8 +11,8 @@ on:
       - main
 
 # Cancel superseded runs for the same ref to free shared runner capacity.
-# The condition keeps cancellation limited to pull_request events, so
-# merge_group and workflow_dispatch runs are never cancelled.
+# Only cancel PR runs; other events get a unique group so their runs never
+# cancel or drop each other.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -8,6 +8,13 @@ on:
       - synchronize
   merge_group:
 
+# Cancel superseded runs for the same ref to free shared runner capacity.
+# The condition keeps cancellation limited to PR events, so merge_group runs
+# are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 jobs:
   dry-run:
     uses: cloudscape-design/actions/.github/workflows/lint-pr.yml@main

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -8,13 +8,6 @@ on:
       - synchronize
   merge_group:
 
-# Cancel superseded runs for the same ref to free shared runner capacity.
-# The condition keeps cancellation limited to PR events, so merge_group runs
-# are never cancelled.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
-
 jobs:
   dry-run:
     uses: cloudscape-design/actions/.github/workflows/lint-pr.yml@main


### PR DESCRIPTION
### Description

Ticket: P509155352

### How has this been tested?

On this PR, once I updated the PR with a new commit (merged main), the [initial dry-run workflow](https://github.com/cloudscape-design/components/actions/runs/34453079940/job/102793206413?pr=4992) did not fully run, as expected (not-yet started jobs were not triggered).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
