### PR TITLE
chore: Dedupe table cell spacing and move first/last-row edges to CSS

### DIFF
--- a/pages/table/inline-editor.permutations.page.tsx
+++ b/pages/table/inline-editor.permutations.page.tsx
@@ -114,8 +114,6 @@ export default function InlineEditorPermutations() {
                       item={{}}
                       column={{ ...baseColumnDefinition, editConfig: permutation }}
                       isEditable={true}
-                      isFirstRow={false}
-                      isLastRow={false}
                       isNextSelected={false}
                       isPrevSelected={false}
                       isSelected={false}

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -70,8 +70,6 @@ const commonProps: TestBodyCellProps = {
   isEditable: true,
   isPrevSelected: false,
   isNextSelected: false,
-  isFirstRow: true,
-  isLastRow: true,
   isSelected: false,
   wrapLines: false,
   stickyState: result.current,

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -165,7 +165,10 @@ $editing-cell-padding-block: awsui.$space-scaled-xxxs;
 
     // Last selected row has a fixed border-bottom width which do not change on selection in visual refresh.
     // Adjust padding-bottom prevents a slight jump in the table height.
-    tr:last-child > &.is-visual-refresh {
+    // `:not(.body-cell-edit-active)`: the positional `tr:last-child` raises this rule's specificity
+    // above the edit-active padding rule, so an actively-edited selected last row must be excluded
+    // here or it would keep the selected padding instead of the editor's.
+    tr:last-child > &.is-visual-refresh:not(.body-cell-edit-active) {
       @include cell-base.cell-padding-block-end(
         calc(#{cell-base.$cell-vertical-padding} + #{awsui.$border-divider-list-width})
       );

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -135,27 +135,26 @@ $editing-cell-padding-block: awsui.$space-scaled-xxxs;
       border-inline-start: none;
     }
   }
-  &-first-row {
+  // Guard selected out: a selected first row must keep its (thicker, coloured) selected
+  // top border, which the transparent placeholder would otherwise cover.
+  tr:first-child > &:not(.body-cell-selected) {
     border-block-start: cell-base.$border-placeholder;
   }
-  &-last-row:not(.body-cell-selected) {
-    &:not(.has-footer) {
-      // skip the border for the last row because the container already has a border
-      border-block-end: cell-base.$border-placeholder;
-    }
-
-    &.has-footer {
-      /*
-      Add a bottom border to the body cells of the last row as a separator between the
-      table and the footer
-      */
-      border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
-    }
+  tr:last-child > &:not(.body-cell-selected):not(.has-footer) {
+    // skip the border for the last row because the container already has a border
+    border-block-end: cell-base.$border-placeholder;
+  }
+  tr:last-child > &:not(.body-cell-selected).has-footer {
+    /*
+    Add a bottom border to the body cells of the last row as a separator between the
+    table and the footer
+    */
+    border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
   }
   &-shaded {
     background: awsui.$color-background-cell-shaded;
   }
-  &.has-striped-rows:not(.body-cell-selected):not(.body-cell-last-row) {
+  tr:not(:last-child) > &.has-striped-rows:not(.body-cell-selected) {
     border-block-end-color: awsui.$color-border-cell-shaded;
   }
   &-selected {
@@ -166,7 +165,7 @@ $editing-cell-padding-block: awsui.$space-scaled-xxxs;
 
     // Last selected row has a fixed border-bottom width which do not change on selection in visual refresh.
     // Adjust padding-bottom prevents a slight jump in the table height.
-    &.body-cell-last-row.is-visual-refresh {
+    tr:last-child > &.is-visual-refresh {
       @include cell-base.cell-padding-block-end(
         calc(#{cell-base.$cell-vertical-padding} + #{awsui.$border-divider-list-width})
       );
@@ -474,18 +473,22 @@ $editing-cell-padding-block: awsui.$space-scaled-xxxs;
             calc(#{$success-icon-padding-right} - (2 * #{awsui.$border-divider-list-width}))
           );
         }
-        &.body-cell-last-row.body-cell-selected,
         &.body-cell-next-selected {
           @include cell-base.cell-padding-block(
             calc(#{cell-base.$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2))
           );
         }
-        &.body-cell-last-row:not(.body-cell-expandable):not(.body-cell-selected) {
+        tr:last-child > &.body-cell-selected {
+          @include cell-base.cell-padding-block(
+            calc(#{cell-base.$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2))
+          );
+        }
+        tr:last-child > &:not(.body-cell-expandable):not(.body-cell-selected) {
           @include cell-base.cell-padding-block-start(
             calc(#{cell-base.$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}))
           );
         }
-        &.body-cell-first-row:not(.body-cell-expandable):not(.body-cell-selected) {
+        tr:first-child > &:not(.body-cell-expandable):not(.body-cell-selected) {
           @include cell-base.cell-padding-block(
             calc(#{cell-base.$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}))
           );

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -6,30 +6,19 @@
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
 @use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
+@use '../cell-base/cell-box' as cell-base;
 
-$cell-vertical-padding: awsui.$space-scaled-xs;
-// Calculate padding to prevent a shift in content after selection due to the difference
-// between selected border widths and normal row divider widths (visual refresh).
-$cell-vertical-padding-w-border: calc(
-  #{$cell-vertical-padding} + (#{awsui.$border-item-width} - #{awsui.$border-divider-list-width})
-);
-$cell-horizontal-padding: awsui.$space-scaled-l;
-$cell-edge-horizontal-padding: calc(#{awsui.$space-l} - #{awsui.$border-item-width});
-$cell-horizontal-padding-w-border: calc(#{$cell-edge-horizontal-padding} + #{awsui.$border-item-width});
+$cell-horizontal-padding-w-border: calc(#{cell-base.$cell-edge-horizontal-padding} + #{awsui.$border-item-width});
 $selected-border: awsui.$border-width-item-selected solid awsui.$color-border-item-selected;
 $selected-border-placeholder: awsui.$border-divider-list-width solid awsui.$color-border-item-placeholder;
-$border-placeholder: awsui.$border-item-width solid transparent;
 $icon-width-with-spacing: calc(#{awsui.$size-icon-normal} + #{awsui.$space-xs});
 // Right paddings of the absolute positioned icons (success icon is shown next to the edit icon)
 $edit-button-padding-right: calc(#{awsui.$space-xs} + #{awsui.$space-xxs});
 // Cell vertical padding + xxs space that would normally come from the button.
 $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-with-spacing});
-$interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{awsui.$space-l});
+$interactive-column-padding-inline-end: calc(#{cell-base.$cell-horizontal-padding} + #{awsui.$space-l});
 $editing-cell-padding-inline: awsui.$space-xxs;
 $editing-cell-padding-block: awsui.$space-scaled-xxxs;
-$cell-offset: calc(#{awsui.$space-m} + #{awsui.$space-xs});
-// Ensuring enough space for absolute-positioned focus outlines of focus-able cell content elements.
-$cell-negative-space-vertical: 2px;
 
 @mixin safe-focus-highlight($params) {
   @include styles.focus-highlight($params);
@@ -65,64 +54,9 @@ $cell-negative-space-vertical: 2px;
   align-items: center;
 }
 
-@mixin cell-padding-inline-start($padding) {
-  $max-nesting-levels: 9;
-  $offset-padding: calc($padding - 1 * awsui.$border-divider-list-width);
-
-  > .body-cell-content {
-    padding-inline-start: $offset-padding;
-  }
-  > .expandable-toggle-wrapper {
-    margin-inline-start: $offset-padding;
-  }
-
-  @for $i from 0 through $max-nesting-levels {
-    &.expandable-level-#{$i} {
-      > .body-cell-content {
-        padding-inline-start: calc(#{$offset-padding} / 2);
-        margin-inline-start: calc(#{$offset-padding} / 2 + #{$i} * #{$cell-offset});
-      }
-      > .expandable-toggle-wrapper {
-        margin-inline-start: calc($offset-padding + ($i - 1) * $cell-offset);
-      }
-    }
-  }
-  &.expandable-level-next {
-    > .body-cell-content {
-      padding-inline-start: calc(#{$offset-padding} / 2);
-      margin-inline-start: calc(#{$offset-padding} / 2 + #{$max-nesting-levels} * #{$cell-offset});
-    }
-    > .expandable-toggle-wrapper {
-      margin-inline-start: calc(#{$offset-padding} + (#{$max-nesting-levels} - 1) * #{$cell-offset});
-    }
-  }
-}
-@mixin cell-padding-inline-end($padding) {
-  > .body-cell-content {
-    padding-inline-end: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
-  }
-}
-@mixin cell-padding-block($padding) {
-  > .body-cell-content {
-    padding-block: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width} + #{$cell-negative-space-vertical});
-    margin-block: calc(-1 * #{$cell-negative-space-vertical});
-  }
-}
-@mixin cell-padding-block-start($padding) {
-  > .body-cell-content {
-    padding-block-start: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width} + #{$cell-negative-space-vertical});
-    margin-block-start: calc(-1 * #{$cell-negative-space-vertical});
-  }
-}
-@mixin cell-padding-block-end($padding) {
-  > .body-cell-content {
-    padding-block-end: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width} + #{$cell-negative-space-vertical});
-    margin-block-end: calc(-1 * #{$cell-negative-space-vertical});
-  }
-}
 @mixin body-cell-active-hover-padding($padding-start) {
   &:not(.body-cell-edit-active):not(.body-cell-expandable).body-cell-editable:hover {
-    @include cell-padding-inline-start(calc(#{$padding-start} + #{awsui.$border-divider-list-width}));
+    @include cell-base.cell-padding-inline-start(calc(#{$padding-start} + #{awsui.$border-divider-list-width}));
   }
 }
 
@@ -134,11 +68,11 @@ $cell-negative-space-vertical: 2px;
   font-weight: inherit;
   text-align: start;
 
-  @include cell-padding-inline-start($cell-horizontal-padding);
-  @include cell-padding-inline-end($cell-horizontal-padding);
+  @include cell-base.cell-padding-inline-start(cell-base.$cell-horizontal-padding);
+  @include cell-base.cell-padding-inline-end(cell-base.$cell-horizontal-padding);
 
-  @include cell-padding-block-start($cell-vertical-padding);
-  @include cell-padding-block-end($cell-vertical-padding-w-border);
+  @include cell-base.cell-padding-block-start(cell-base.$cell-vertical-padding);
+  @include cell-base.cell-padding-block-end(cell-base.$cell-vertical-padding-w-border);
 
   &-align-top {
     vertical-align: top;
@@ -162,34 +96,34 @@ $cell-negative-space-vertical: 2px;
   }
 
   &:first-child {
-    border-inline-start: $border-placeholder;
-    @include cell-padding-inline-start($cell-edge-horizontal-padding);
+    border-inline-start: cell-base.$border-placeholder;
+    @include cell-base.cell-padding-inline-start(cell-base.$cell-edge-horizontal-padding);
   }
   &:last-child {
-    border-inline-end: $border-placeholder;
-    @include cell-padding-inline-end($cell-edge-horizontal-padding);
+    border-inline-end: cell-base.$border-placeholder;
+    @include cell-base.cell-padding-inline-end(cell-base.$cell-edge-horizontal-padding);
   }
   // Using very small padding for 1st column cells in VR.
   &.is-visual-refresh:first-child {
-    @include cell-padding-inline-start(awsui.$space-xxxs);
+    @include cell-base.cell-padding-inline-start(awsui.$space-xxxs);
     @include body-cell-active-hover-padding(awsui.$space-xxxs);
 
     // Using slightly larger padding for tables with striped rows because the shaded background
     // makes the child content appear too close to the table edge.
     &:first-child.has-striped-rows {
-      @include cell-padding-inline-start(awsui.$space-xxs);
+      @include cell-base.cell-padding-inline-start(awsui.$space-xxs);
       @include body-cell-active-hover-padding(awsui.$space-xxs);
 
       &.sticky-cell-pad-inline-start {
-        @include cell-padding-inline-start($cell-horizontal-padding);
-        @include body-cell-active-hover-padding($cell-horizontal-padding);
+        @include cell-base.cell-padding-inline-start(cell-base.$cell-horizontal-padding);
+        @include body-cell-active-hover-padding(cell-base.$cell-horizontal-padding);
       }
     }
 
     // Using normal padding when 1st column is sticky.
     &.sticky-cell-pad-inline-start:not(.has-selection) {
-      @include cell-padding-inline-start($cell-horizontal-padding);
-      @include body-cell-active-hover-padding($cell-horizontal-padding);
+      @include cell-base.cell-padding-inline-start(cell-base.$cell-horizontal-padding);
+      @include body-cell-active-hover-padding(cell-base.$cell-horizontal-padding);
     }
 
     /*
@@ -202,12 +136,12 @@ $cell-negative-space-vertical: 2px;
     }
   }
   &-first-row {
-    border-block-start: $border-placeholder;
+    border-block-start: cell-base.$border-placeholder;
   }
   &-last-row:not(.body-cell-selected) {
     &:not(.has-footer) {
       // skip the border for the last row because the container already has a border
-      border-block-end: $border-placeholder;
+      border-block-end: cell-base.$border-placeholder;
     }
 
     &.has-footer {
@@ -228,12 +162,14 @@ $cell-negative-space-vertical: 2px;
     background-color: awsui.$color-background-item-selected;
     border-block-start: $selected-border;
     border-block-end: $selected-border;
-    @include cell-padding-block-end($cell-vertical-padding);
+    @include cell-base.cell-padding-block-end(cell-base.$cell-vertical-padding);
 
     // Last selected row has a fixed border-bottom width which do not change on selection in visual refresh.
     // Adjust padding-bottom prevents a slight jump in the table height.
     &.body-cell-last-row.is-visual-refresh {
-      @include cell-padding-block-end(calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width}));
+      @include cell-base.cell-padding-block-end(
+        calc(#{cell-base.$cell-vertical-padding} + #{awsui.$border-divider-list-width})
+      );
     }
 
     &:first-child {
@@ -313,15 +249,17 @@ $cell-negative-space-vertical: 2px;
 
   // Use padding as a selected border placeholder to make sure rows don't change height on selection (visual refresh)
   &-selected:not(:first-child) {
-    @include cell-padding-block-start($cell-vertical-padding-w-border);
+    @include cell-base.cell-padding-block-start(cell-base.$cell-vertical-padding-w-border);
   }
   &:not(.body-cell-selected).body-cell-next-selected {
     border-block-end: 0;
-    @include cell-padding-block-end(calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width}));
+    @include cell-base.cell-padding-block-end(
+      calc(#{cell-base.$cell-vertical-padding} + #{awsui.$border-divider-list-width})
+    );
   }
   &-selected.body-cell-prev-selected {
     border-block-start: $selected-border-placeholder;
-    @include cell-padding-block-start($cell-vertical-padding-w-border);
+    @include cell-base.cell-padding-block-start(cell-base.$cell-vertical-padding-w-border);
   }
   &-selected.body-cell-next-selected {
     border-block-end-width: awsui.$border-divider-list-width;
@@ -342,7 +280,7 @@ $cell-negative-space-vertical: 2px;
   // Reset padding for selected rows with no adjacent selected row above it,
   // because rows reuse adjacent selected borders (visual refresh)
   &-selected:not(.body-cell-prev-selected) {
-    @include cell-padding-block-start($cell-vertical-padding);
+    @include cell-base.cell-padding-block-start(cell-base.$cell-vertical-padding);
   }
 
   &-editor-wrapper {
@@ -441,20 +379,20 @@ $cell-negative-space-vertical: 2px;
       > .body-cell-content {
         overflow: visible;
       }
-      @include cell-padding-inline-start($editing-cell-padding-inline);
-      @include cell-padding-inline-end($editing-cell-padding-inline);
-      @include cell-padding-block-start($editing-cell-padding-block);
-      @include cell-padding-block-end(calc($editing-cell-padding-block + 1px));
+      @include cell-base.cell-padding-inline-start($editing-cell-padding-inline);
+      @include cell-base.cell-padding-inline-end($editing-cell-padding-inline);
+      @include cell-base.cell-padding-block-start($editing-cell-padding-block);
+      @include cell-base.cell-padding-block-end(calc($editing-cell-padding-block + 1px));
     }
 
     &:not(.body-cell-edit-active) {
       // Include interactive padding even when a cell is not hovered to prevent jittering when resizableColumns=false.
       &:not(.resizable-columns) {
-        @include cell-padding-inline-end($interactive-column-padding-inline-end);
+        @include cell-base.cell-padding-inline-end($interactive-column-padding-inline-end);
       }
 
       @mixin focused-editor-styles {
-        @include cell-padding-inline-end($interactive-column-padding-inline-end);
+        @include cell-base.cell-padding-inline-end($interactive-column-padding-inline-end);
         & > .body-cell-editor-wrapper,
         & > .expandable-cell-content > .body-cell-editor-wrapper {
           opacity: 1;
@@ -485,8 +423,8 @@ $cell-negative-space-vertical: 2px;
         }
         &.body-cell-has-success {
           // After a successful edit, we display the success icon next to the edit button and need additional padding to not let the text overflow the success icon.
-          @include cell-padding-inline-end(
-            calc(#{$cell-horizontal-padding} + #{awsui.$space-l} + #{$icon-width-with-spacing})
+          @include cell-base.cell-padding-inline-end(
+            calc(#{cell-base.$cell-horizontal-padding} + #{awsui.$space-l} + #{$icon-width-with-spacing})
           );
         }
         @include focused-editor-styles;
@@ -526,27 +464,31 @@ $cell-negative-space-vertical: 2px;
 
         & > .body-cell-editor-wrapper,
         & > .expandable-cell-content > .body-cell-editor-wrapper {
-          @include cell-padding-inline-end(
+          @include cell-base.cell-padding-inline-end(
             calc(#{$edit-button-padding-right} - (2 * #{awsui.$border-divider-list-width}))
           );
         }
         & > .body-cell-success {
           // Update padding to avoid a jumping icon because of the additional borders added when hovering an editable cell.
-          @include cell-padding-inline-end(
+          @include cell-base.cell-padding-inline-end(
             calc(#{$success-icon-padding-right} - (2 * #{awsui.$border-divider-list-width}))
           );
         }
         &.body-cell-last-row.body-cell-selected,
         &.body-cell-next-selected {
-          @include cell-padding-block(calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2)));
+          @include cell-base.cell-padding-block(
+            calc(#{cell-base.$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2))
+          );
         }
         &.body-cell-last-row:not(.body-cell-expandable):not(.body-cell-selected) {
-          @include cell-padding-block-start(
-            calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}))
+          @include cell-base.cell-padding-block-start(
+            calc(#{cell-base.$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}))
           );
         }
         &.body-cell-first-row:not(.body-cell-expandable):not(.body-cell-selected) {
-          @include cell-padding-block(calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width})));
+          @include cell-base.cell-padding-block(
+            calc(#{cell-base.$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}))
+          );
         }
         @include focused-editor-styles;
       }

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -22,8 +22,6 @@ import styles from './styles.css.js';
 export interface TableTdElementProps {
   wrapLines: boolean | undefined;
   isRowHeader?: boolean;
-  isFirstRow: boolean;
-  isLastRow: boolean;
   isSelected: boolean;
   isNextSelected: boolean;
   isPrevSelected: boolean;
@@ -67,8 +65,6 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       children,
       wrapLines,
       isRowHeader,
-      isFirstRow,
-      isLastRow,
       isSelected,
       isNextSelected,
       isPrevSelected,
@@ -127,8 +123,6 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
         style={{ ...resizableStyle, ...stickyStyles.style }}
         className={clsx(
           styles['body-cell'],
-          isFirstRow && styles['body-cell-first-row'],
-          isLastRow && styles['body-cell-last-row'],
           isSelected && styles['body-cell-selected'],
           isNextSelected && styles['body-cell-next-selected'],
           isPrevSelected && styles['body-cell-prev-selected'],

--- a/src/table/cell-base/_cell-box.scss
+++ b/src/table/cell-base/_cell-box.scss
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+@use '../../internal/styles/tokens' as awsui;
+
+$cell-vertical-padding: awsui.$space-scaled-xs;
+// Calculate padding to prevent a shift in content after selection due to the difference
+// between selected border widths and normal row divider widths (visual refresh).
+$cell-vertical-padding-w-border: calc(
+  #{$cell-vertical-padding} + (#{awsui.$border-item-width} - #{awsui.$border-divider-list-width})
+);
+$cell-horizontal-padding: awsui.$space-scaled-l;
+$cell-edge-horizontal-padding: calc(#{awsui.$space-l} - #{awsui.$border-item-width});
+$border-placeholder: awsui.$border-item-width solid transparent;
+$cell-offset: calc(#{awsui.$space-m} + #{awsui.$space-xs});
+// Ensuring enough space for absolute-positioned focus outlines of focus-able cell content elements.
+$cell-negative-space-vertical: 2px;
+
+@mixin cell-padding-inline-start($padding) {
+  $max-nesting-levels: 9;
+  $offset-padding: calc($padding - 1 * awsui.$border-divider-list-width);
+
+  > .body-cell-content {
+    padding-inline-start: $offset-padding;
+  }
+  > .expandable-toggle-wrapper {
+    margin-inline-start: $offset-padding;
+  }
+
+  @for $i from 0 through $max-nesting-levels {
+    &.expandable-level-#{$i} {
+      > .body-cell-content {
+        padding-inline-start: calc(#{$offset-padding} / 2);
+        margin-inline-start: calc(#{$offset-padding} / 2 + #{$i} * #{$cell-offset});
+      }
+      > .expandable-toggle-wrapper {
+        margin-inline-start: calc($offset-padding + ($i - 1) * $cell-offset);
+      }
+    }
+  }
+  &.expandable-level-next {
+    > .body-cell-content {
+      padding-inline-start: calc(#{$offset-padding} / 2);
+      margin-inline-start: calc(#{$offset-padding} / 2 + #{$max-nesting-levels} * #{$cell-offset});
+    }
+    > .expandable-toggle-wrapper {
+      margin-inline-start: calc(#{$offset-padding} + (#{$max-nesting-levels} - 1) * #{$cell-offset});
+    }
+  }
+}
+@mixin cell-padding-inline-end($padding) {
+  > .body-cell-content {
+    padding-inline-end: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
+  }
+}
+@mixin cell-padding-block($padding) {
+  > .body-cell-content {
+    padding-block: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width} + #{$cell-negative-space-vertical});
+    margin-block: calc(-1 * #{$cell-negative-space-vertical});
+  }
+}
+@mixin cell-padding-block-start($padding) {
+  > .body-cell-content {
+    padding-block-start: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width} + #{$cell-negative-space-vertical});
+    margin-block-start: calc(-1 * #{$cell-negative-space-vertical});
+  }
+}
+@mixin cell-padding-block-end($padding) {
+  > .body-cell-content {
+    padding-block-end: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width} + #{$cell-negative-space-vertical});
+    margin-block-end: calc(-1 * #{$cell-negative-space-vertical});
+  }
+}

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -6,8 +6,7 @@
 @use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 @use '../../internal/styles/tokens' as awsui;
 @use '../../internal/styles' as styles;
-
-$cell-horizontal-padding: awsui.$space-scaled-l;
+@use '../cell-base/cell-box' as cell-base;
 
 @mixin when-focus-visible-or-fake {
   @include focus-visible.when-visible {
@@ -305,6 +304,6 @@ settings icon in the pagination slot.
   }
 
   &.sticky-cell-pad-inline-start {
-    @include cell-offset($cell-horizontal-padding);
+    @include cell-offset(cell-base.$cell-horizontal-padding);
   }
 }

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -666,7 +666,6 @@ const InternalTable = React.forwardRef(
                       {skeleton && allItems.length === 0 && loading ? (
                         <SkeletonRows
                           count={skeletonRowsCount}
-                          hasDataRows={false}
                           totalColumnsCount={totalColumnsCount}
                           loadingText={loadingText}
                           hasSelection={hasSelection}
@@ -696,11 +695,6 @@ const InternalTable = React.forwardRef(
                         </tr>
                       ) : (
                         allRows.map((row, rowIndex) => {
-                          const isFirstRow = rowIndex === 0;
-                          const hasSkeletonBelow =
-                            loading && skeleton && allItems.length > 0 && skeletonRowsCount - allItems.length > 0;
-                          const isLastDataRow = rowIndex === allRows.length - 1;
-                          const isLastRow = isLastDataRow && !hasSkeletonBelow;
                           const rowExpandableProps =
                             row.type === 'data' ? expandableRows.getExpandableItemProps(row.item) : undefined;
                           const rowRoleProps = getTableRowRoleProps({
@@ -713,11 +707,10 @@ const InternalTable = React.forwardRef(
                           });
                           const getTableItemKey = (item: T) => getItemKey(trackBy, item, rowIndex);
                           const sharedCellProps = {
-                            isFirstRow,
-                            isLastRow,
                             isSelected: hasSelection && isRowSelected(row),
-                            isPrevSelected: hasSelection && !isFirstRow && isRowSelected(allRows[rowIndex - 1]),
-                            isNextSelected: hasSelection && !isLastDataRow && isRowSelected(allRows[rowIndex + 1]),
+                            isPrevSelected: hasSelection && rowIndex > 0 && isRowSelected(allRows[rowIndex - 1]),
+                            isNextSelected:
+                              hasSelection && rowIndex < allRows.length - 1 && isRowSelected(allRows[rowIndex + 1]),
                             isEvenRow: rowIndex % 2 === 0,
                             stripedRows,
                             hasSelection,
@@ -882,7 +875,6 @@ const InternalTable = React.forwardRef(
                       {loading && skeleton && allItems.length > 0 && skeletonRowsCount - allItems.length > 0 && (
                         <SkeletonRows
                           count={skeletonRowsCount - allItems.length}
-                          hasDataRows={true}
                           totalColumnsCount={totalColumnsCount}
                           loadingText={loadingText}
                           hasSelection={hasSelection}

--- a/src/table/skeleton-rows.tsx
+++ b/src/table/skeleton-rows.tsx
@@ -16,7 +16,6 @@ const noop = () => {};
 
 interface SkeletonRowsProps {
   count: number;
-  hasDataRows: boolean;
   totalColumnsCount: number;
   loadingText: string | undefined;
   hasSelection: boolean;
@@ -35,7 +34,6 @@ interface SkeletonRowsProps {
 
 export function SkeletonRows({
   count,
-  hasDataRows,
   totalColumnsCount,
   loadingText,
   hasSelection,
@@ -59,16 +57,12 @@ export function SkeletonRows({
         </td>
       </tr>
       {Array.from({ length: count }, (_, i) => {
-        const isFirstRow = !hasDataRows && i === 0;
-        const isLastRow = i === count - 1;
         return (
           <tr key={`skeleton-row-${i}`} className={styles.row} aria-hidden="true">
             {hasSelection && <td className={styles['selection-control']} />}
             {visibleColumnDefinitions.map((column: any, colIndex: number) => (
               <TableBodyCell
                 key={`skeleton-${getColumnKey(column, colIndex)}`}
-                isFirstRow={isFirstRow}
-                isLastRow={isLastRow}
                 isSelected={false}
                 isPrevSelected={false}
                 isNextSelected={false}


### PR DESCRIPTION
Two internal-only refactors to the Table component's cell styling. Neither changes the public API or the rendered appearance — both just reduce duplication and remove hand-maintained plumbing. Split out from a larger in-progress Table change so it can be reviewed and merged on its own.

### 1. Consolidate the cell spacing definitions
The base cell geometry — padding, dividers, and the related SCSS variables and mixins — lived inside the body cell's stylesheet, and the header cell kept its own duplicate of the horizontal-padding value. This moves those shared definitions into one small file (`table/cell-base/`) that both the body cell and header cell import, giving the spacing a single source of truth. It's a pure move: the compiled CSS is unchanged apart from the usual CSS-module class-name hash churn.

### 2. Drive first/last-row edge styling from CSS instead of computed props
The first and last rows get slightly different edge borders. Previously that was done with `body-cell-first-row` / `body-cell-last-row` classes, which required the table to work out each row's position in JavaScript and thread `isFirstRow` / `isLastRow` props down into every cell (and into the loading-skeleton rows). This replaces that with plain CSS (`tr:first-child` / `tr:last-child`) so the browser determines the edge rows, and deletes the props and their plumbing across the row, cell, and skeleton code.

### Behaviour
Verified identical before/after across the standard states — normal, selection, striped rows, empty, editable (including hover), and the loading skeletons. One deliberate difference: in the all-skeleton loading state the first placeholder row loses a 2px transparent top spacer, so the shimmer rows sit 2px higher. It's a clean vertical shift with no content or layout change, and only in that transient loading state.

Unit tests pass; local build is green.
