### PR TITLE
fix: Disabled toggle button hover state

### DIFF
--- a/pages/toggle-button/test-hover.page.tsx
+++ b/pages/toggle-button/test-hover.page.tsx
@@ -17,13 +17,45 @@ const permutations = createPermutations<ToggleButtonProps>([
     pressed: [false, true],
   },
   {
+    variant: ['normal'],
+    children: ['Favorite'],
+    iconName: ['star'],
+    pressedIconName: ['star-filled'],
+    pressed: [false, true],
+    disabled: [true],
+  },
+  {
+    variant: ['normal'],
+    children: ['Favorite'],
+    iconName: ['star'],
+    pressedIconName: ['star-filled'],
+    pressed: [false, true],
+    disabled: [true],
+    disabledReason: ['No permission'],
+  },
+  {
     variant: ['icon'],
     iconName: ['star'],
     ariaLabel: ['Favorite'],
     pressedIconName: ['star-filled'],
     pressed: [false, true],
   },
+  {
+    variant: ['icon'],
+    iconName: ['star'],
+    ariaLabel: ['Favorite'],
+    pressedIconName: ['star-filled'],
+    pressed: [false, true],
+    disabled: [true],
+  },
 ]);
+
+function getTestId(permutation: ToggleButtonProps) {
+  const variant = permutation.variant ?? 'normal';
+  const state = permutation.disabled ? (permutation.disabledReason ? 'disabled-reason' : 'disabled') : 'enabled';
+  const pressedState = permutation.pressed ? 'pressed' : 'not-pressed';
+  return `variant-${variant}-${state}-${pressedState}`;
+}
 
 export default function ToggleButtonTestHover() {
   return (
@@ -32,10 +64,7 @@ export default function ToggleButtonTestHover() {
       <ScreenshotArea>
         <PermutationsView
           permutations={permutations}
-          render={permutation => {
-            const testId = `variant-${permutation.variant ?? 'normal'}-${permutation.pressed ? 'pressed' : 'not-pressed'}`;
-            return <ToggleButton {...permutation} data-testid={testId} />;
-          }}
+          render={permutation => <ToggleButton {...permutation} data-testid={getTestId(permutation)} />}
         />
       </ScreenshotArea>
     </>

--- a/src/toggle-button/__integ__/toggle-button.test.ts
+++ b/src/toggle-button/__integ__/toggle-button.test.ts
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+class ToggleButtonHoverPage extends BasePageObject {
+  getBackgroundColor(testId: string) {
+    return this.browser.$(`[data-testid="${testId}"]`).getCSSProperty('background-color');
+  }
+
+  hover(testId: string) {
+    return this.hoverElement(`[data-testid="${testId}"]`);
+  }
+}
+
+const setupTest = (testFn: (page: ToggleButtonHoverPage) => Promise<void>) =>
+  useBrowser(async browser => {
+    await browser.url('#/light/toggle-button/test-hover');
+    const page = new ToggleButtonHoverPage(browser);
+    await page.waitForVisible('[data-testid="variant-normal-enabled-not-pressed"]');
+    await testFn(page);
+  });
+
+describe('ToggleButton hover', () => {
+  test(
+    'enabled normal variant changes background on hover',
+    setupTest(async page => {
+      const testId = 'variant-normal-enabled-not-pressed';
+      const before = (await page.getBackgroundColor(testId)).value;
+      await page.hover(testId);
+      const after = (await page.getBackgroundColor(testId)).value;
+      expect(after).not.toBe(before);
+    })
+  );
+
+  test(
+    'disabled normal variant (native `disabled`) does not change background on hover',
+    setupTest(async page => {
+      const testId = 'variant-normal-disabled-not-pressed';
+      const before = (await page.getBackgroundColor(testId)).value;
+      await page.hover(testId);
+      const after = (await page.getBackgroundColor(testId)).value;
+      expect(after).toBe(before);
+    })
+  );
+
+  test(
+    'disabled normal variant with reason (`aria-disabled`) does not change background on hover',
+    setupTest(async page => {
+      const testId = 'variant-normal-disabled-reason-not-pressed';
+      const before = (await page.getBackgroundColor(testId)).value;
+      await page.hover(testId);
+      const after = (await page.getBackgroundColor(testId)).value;
+      expect(after).toBe(before);
+    })
+  );
+});

--- a/src/toggle-button/styles.scss
+++ b/src/toggle-button/styles.scss
@@ -9,7 +9,7 @@
   background: awsui.$color-background-toggle-button-normal-default;
   border-color: awsui.$color-border-toggle-button-normal-default;
 
-  &:hover {
+  &:not(:disabled):not([aria-disabled='true']):hover {
     background: awsui.$color-background-toggle-button-normal-hover;
     border-color: awsui.$color-border-toggle-button-normal-hover;
   }


### PR DESCRIPTION
#4621 introduced an issue, which caused the toggle button to have a hover state when disabled. This PR fixes it by gating the normal variant's `:hover` styles behind `:not(:disabled):not([aria-disabled='true'])`, so the hover background and border are no longer applied when the button is disabled. This matches the base button behavior, where the disabled styling takes precedence over hover.

Related: [AWSUI-62272]

https://github.com/user-attachments/assets/d5e4ffa5-f630-4d1e-ac21-ef61ac5cd4d9

