### PR TITLE
feat: Add support for disabledReason for inline link buttons

### DIFF
--- a/pages/button-dropdown/disabled-reason.page.tsx
+++ b/pages/button-dropdown/disabled-reason.page.tsx
@@ -176,6 +176,15 @@ export default function DescriptionPage() {
           />
         </div>
         <div style={{ float: isRightAligned ? 'right' : undefined, marginBottom: '100px' }}>
+          <ButtonDropdown
+            items={actionsItems}
+            ariaLabel="Instance actions"
+            variant="inline-icon"
+            disabled={true}
+            disabledReason="disabled reason"
+          />
+        </div>
+        <div style={{ float: isRightAligned ? 'right' : undefined, marginBottom: '100px' }}>
           <ButtonDropdown items={selectableGroupItems} data-testid="buttonDropdownSelectableItems">
             Selectable example
           </ButtonDropdown>

--- a/pages/button/disabled-reason.page.tsx
+++ b/pages/button/disabled-reason.page.tsx
@@ -33,6 +33,19 @@ export default function ButtonsScenario() {
           iconName="star"
           ariaLabel="Disabled reason icon button"
         />
+        <Button variant="link" disabled={true} disabledReason="disabled reason">
+          Link
+        </Button>
+        <Button variant="inline-link" disabled={true} disabledReason="disabled reason">
+          Inline link
+        </Button>
+        <Button
+          variant="inline-icon"
+          disabled={true}
+          disabledReason="disabled reason"
+          iconName="star"
+          ariaLabel="Disabled reason inline icon button"
+        />
       </ScreenshotArea>
     </article>
   );

--- a/pages/copy-to-clipboard/disabled-reason.page.tsx
+++ b/pages/copy-to-clipboard/disabled-reason.page.tsx
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { Box, CopyToClipboard, SpaceBetween } from '~components';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+const textToCopy = 'Lorem ipsum dolor sit amet';
+
+export default function CopyToClipboardDisabledReasonScenario() {
+  return (
+    <ScreenshotArea>
+      <Box>
+        <SpaceBetween size="l">
+          <h1>Copy to clipboard with disabled reason</h1>
+
+          <CopyToClipboard
+            data-testid="disabled-button"
+            variant="button"
+            copyButtonText="Copy"
+            textToCopy={textToCopy}
+            copySuccessText="Text copied"
+            copyErrorText="Text failed to copy"
+            disabled={true}
+            disabledReason="This action is available when a resource has been selected."
+          />
+
+          <CopyToClipboard
+            data-testid="disabled-icon"
+            variant="icon"
+            copyButtonAriaLabel="Copy text"
+            textToCopy={textToCopy}
+            copySuccessText="Text copied"
+            copyErrorText="Text failed to copy"
+            disabled={true}
+            disabledReason="This action is available when a resource has been selected."
+          />
+
+          <CopyToClipboard
+            data-testid="disabled-inline"
+            variant="inline"
+            copyButtonAriaLabel="Copy text"
+            textToCopy={textToCopy}
+            copySuccessText="Text copied"
+            copyErrorText="Text failed to copy"
+            disabled={true}
+            disabledReason="This action is available when a resource has been selected."
+          />
+        </SpaceBetween>
+      </Box>
+    </ScreenshotArea>
+  );
+}

--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -5578,8 +5578,7 @@ The text will also be added to the \`title\` attribute of the button.",
     },
     {
       "description": "Provides a reason why the button is disabled (only when \`disabled\` is \`true\`).
-If provided, the button becomes focusable.
-Applicable for all button variants, except link.",
+If provided, the button becomes focusable.",
       "name": "disabledReason",
       "optional": true,
       "type": "string",
@@ -10762,8 +10761,7 @@ and to distinguish between multiple buttons with identical visible text. The tex
     },
     {
       "description": "Provides a reason why the copy to clipboard button is disabled (only when \`disabled\` is \`true\`).
-If provided, the copy to clipboard button becomes focusable.
-Applicable for all variants except inline.",
+If provided, the copy to clipboard button becomes focusable.",
       "name": "disabledReason",
       "optional": true,
       "type": "string",

--- a/src/button-dropdown/__tests__/button-dropdown.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown.test.tsx
@@ -107,7 +107,7 @@ const items: ButtonDropdownProps.Items = [
       });
     });
 
-    (['normal', 'primary', 'icon'] as Array<ButtonDropdownProps['variant']>).forEach(variant => {
+    (['normal', 'primary', 'icon', 'inline-icon'] as Array<ButtonDropdownProps['variant']>).forEach(variant => {
       describe(`"${variant}" variant 'disabled with reason`, () => {
         const props = { expandToViewport, variant };
 

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -184,145 +184,133 @@ describe('Button Component', () => {
     });
   });
 
-  describe.each(['link', 'inline-link'] as const)(
-    'disabled with reason ignored for %s variant (not applicable)',
+  describe.each(['primary', 'normal', 'icon', 'inline-icon', 'inline-link', 'link'] as const)(
+    'disabled with reason %s variant',
     variant => {
-      test('does not make a link button focusable when disabledReason is set', () => {
-        const wrapper = renderButton({
+      describe.each([true, false] as const)('with href %s', withHref => {
+        const defaultProps = {
           variant,
-          href: 'https://example.com',
-          disabled: true,
-          disabledReason: 'reason',
+          href: withHref ? 'https://smth.com' : undefined,
+        };
+        test('renders button as normal when disabledReason is set and button is not disabled', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: false, disabledReason: 'reason' });
+
+          expect(wrapper.getElement()).not.toHaveAttribute('disabled');
+          expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
         });
-        expect(wrapper.getElement()).toHaveAttribute('tabIndex', '-1');
+
+        test('does not add disabled attribute when disabled with reason', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          expect(wrapper.getElement()).not.toHaveAttribute('disabled');
+          expect(wrapper.getElement()).toHaveAttribute('aria-disabled');
+        });
+
+        test('has no tooltip open by default', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          expect(wrapper.findDisabledReason()).toBe(null);
+        });
+
+        test('has no tooltip without disabledReason', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true });
+
+          wrapper.getElement()!.focus();
+
+          expect(wrapper.findDisabledReason()).toBeNull();
+        });
+
+        test('open tooltip on focus', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          wrapper.getElement()!.focus();
+
+          expect(wrapper.findDisabledReason()).not.toBeNull();
+          expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+        });
+
+        test('closes tooltip on blur', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          wrapper.getElement()!.focus();
+
+          expect(wrapper.findDisabledReason()).not.toBeNull();
+          expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+
+          wrapper.getElement()!.blur();
+
+          expect(wrapper.findDisabledReason()).toBeNull();
+        });
+
+        test('open tooltip on mouseenter', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          fireEvent.mouseEnter(wrapper.getElement());
+
+          expect(wrapper.findDisabledReason()).not.toBeNull();
+          expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+        });
+
+        test('close tooltip on mouseleave', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          fireEvent.mouseEnter(wrapper.getElement());
+
+          expect(wrapper.findDisabledReason()).not.toBeNull();
+          expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+
+          fireEvent.mouseLeave(wrapper.getElement());
+
+          expect(wrapper.findDisabledReason()).toBeNull();
+        });
+
+        test('close tooltip on Esc keydown', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          fireEvent.mouseEnter(wrapper.getElement());
+
+          expect(wrapper.findDisabledReason()).not.toBeNull();
+          expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
+
+          fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+          expect(wrapper.findDisabledReason()).toBeNull();
+        });
+
+        test('has no aria-describedby by default', () => {
+          const wrapper = renderButton({ ...defaultProps });
+
+          expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
+        });
+
+        test('has no aria-describedby without disabledReason', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true });
+
+          expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
+        });
+
+        test('has aria-describedby with disabledReason', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          expect(wrapper.getElement()).toHaveAttribute('aria-describedby');
+        });
+
+        test('has hidden element (linked to aria-describedby) with disabledReason', () => {
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
+
+          expect(wrapper.find('span[hidden]')!.getElement()).toHaveTextContent('reason');
+        });
+
+        test('does not trigger onClick handler when disabled with reason', () => {
+          const onClick = jest.fn();
+          const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason', onClick });
+
+          wrapper.click();
+
+          expect(onClick).not.toHaveBeenCalled();
+        });
       });
     }
   );
-
-  describe.each(['primary', 'normal', 'icon'] as const)('disabled with reason %s variant', variant => {
-    describe.each([true, false] as const)('with href %s', withHref => {
-      const defaultProps = {
-        variant,
-        href: withHref ? 'https://smth.com' : undefined,
-      };
-      test('renders button as normal when disabledReason is set and button is not disabled', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: false, disabledReason: 'reason' });
-
-        expect(wrapper.getElement()).not.toHaveAttribute('disabled');
-        expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
-      });
-
-      test('does not add disabled attribute when disabled with reason', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        expect(wrapper.getElement()).not.toHaveAttribute('disabled');
-        expect(wrapper.getElement()).toHaveAttribute('aria-disabled');
-      });
-
-      test('has no tooltip open by default', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        expect(wrapper.findDisabledReason()).toBe(null);
-      });
-
-      test('has no tooltip without disabledReason', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true });
-
-        wrapper.getElement()!.focus();
-
-        expect(wrapper.findDisabledReason()).toBeNull();
-      });
-
-      test('open tooltip on focus', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        wrapper.getElement()!.focus();
-
-        expect(wrapper.findDisabledReason()).not.toBeNull();
-        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-      });
-
-      test('closes tooltip on blur', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        wrapper.getElement()!.focus();
-
-        expect(wrapper.findDisabledReason()).not.toBeNull();
-        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-
-        wrapper.getElement()!.blur();
-
-        expect(wrapper.findDisabledReason()).toBeNull();
-      });
-
-      test('open tooltip on mouseenter', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        fireEvent.mouseEnter(wrapper.getElement());
-
-        expect(wrapper.findDisabledReason()).not.toBeNull();
-        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-      });
-
-      test('close tooltip on mouseleave', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        fireEvent.mouseEnter(wrapper.getElement());
-
-        expect(wrapper.findDisabledReason()).not.toBeNull();
-        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-
-        fireEvent.mouseLeave(wrapper.getElement());
-
-        expect(wrapper.findDisabledReason()).toBeNull();
-      });
-
-      test('close tooltip on Esc keydown', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        fireEvent.mouseEnter(wrapper.getElement());
-
-        expect(wrapper.findDisabledReason()).not.toBeNull();
-        expect(wrapper.findDisabledReason()!.getElement()).toHaveTextContent('reason');
-
-        fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
-        expect(wrapper.findDisabledReason()).toBeNull();
-      });
-
-      test('has no aria-describedby by default', () => {
-        const wrapper = renderButton({ ...defaultProps });
-
-        expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
-      });
-
-      test('has no aria-describedby without disabledReason', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true });
-
-        expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
-      });
-
-      test('has aria-describedby with disabledReason', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        expect(wrapper.getElement()).toHaveAttribute('aria-describedby');
-      });
-
-      test('has hidden element (linked to aria-describedby) with disabledReason', () => {
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason' });
-
-        expect(wrapper.find('span[hidden]')!.getElement()).toHaveTextContent('reason');
-      });
-
-      test('does not trigger onClick handler when disabled with reason', () => {
-        const onClick = jest.fn();
-        const wrapper = renderButton({ ...defaultProps, disabled: true, disabledReason: 'reason', onClick });
-
-        wrapper.click();
-
-        expect(onClick).not.toHaveBeenCalled();
-      });
-    });
-  });
 
   describe('iconName property', () => {
     test('does not render icon element when no icon provided', () => {

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -18,7 +18,6 @@ export interface BaseButtonProps {
   /**
    * Provides a reason why the button is disabled (only when `disabled` is `true`).
    * If provided, the button becomes focusable.
-   * Applicable for all button variants, except link.
    */
   disabledReason?: string;
   /**

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -123,7 +123,14 @@ export const InternalButton = React.forwardRef(
     const target = targetOverride ?? (external ? '_blank' : undefined);
     const isNotInteractive = loading || disabled;
     const isDisabledWithReason =
-      (variant === 'normal' || variant === 'primary' || variant === 'icon') && !!disabledReason && disabled;
+      (variant === 'normal' ||
+        variant === 'primary' ||
+        variant === 'icon' ||
+        variant === 'inline-icon' ||
+        variant === 'inline-link' ||
+        variant === 'link') &&
+      !!disabledReason &&
+      disabled;
 
     const hasAriaDisabled = (loading && !disabled) || (disabled && __focusable) || isDisabledWithReason;
     const shouldHaveContent =

--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -222,26 +222,33 @@ describe('CopyToClipboard', () => {
         expect(copyButton.isDisabled()).toBe(true);
       });
 
-      test('sets the disabled reason when button is focused', async () => {
-        const { container } = render(
-          <CopyToClipboard
-            {...defaultProps}
-            popoverRenderWithPortal={popoverRenderWithPortal}
-            textToCopy="Text to copy with error"
-            disabled={true}
-            disabledReason="Disabled reason"
-          />
-        );
-
-        const copyToClipboardButton = createWrapper(container).findCopyToClipboard()!;
-        copyToClipboardButton.findCopyButton()!.focus();
-
-        await waitFor(() => {
-          expect(copyToClipboardButton.findCopyButton()!.findDisabledReason()!.getElement()).toHaveTextContent(
-            'Disabled reason'
+      // The `inline` variant renders the trigger as an `inline-icon` button, which only gained
+      // `disabledReason` support alongside `link` and `inline-link`. Cover every variant so the
+      // trigger mapping in `copy-to-clipboard/internal.tsx` stays wired up.
+      test.each(['button', 'icon', 'inline'] as const)(
+        'sets the disabled reason when the %s variant button is focused',
+        async variant => {
+          const { container } = render(
+            <CopyToClipboard
+              {...defaultProps}
+              popoverRenderWithPortal={popoverRenderWithPortal}
+              variant={variant}
+              textToCopy="Text to copy with error"
+              disabled={true}
+              disabledReason="Disabled reason"
+            />
           );
-        });
-      });
+
+          const copyToClipboardButton = createWrapper(container).findCopyToClipboard()!;
+          copyToClipboardButton.findCopyButton()!.focus();
+
+          await waitFor(() => {
+            expect(copyToClipboardButton.findCopyButton()!.findDisabledReason()!.getElement()).toHaveTextContent(
+              'Disabled reason'
+            );
+          });
+        }
+      );
 
       test('does not show the popover when clicked', () => {
         const { container } = render(

--- a/src/copy-to-clipboard/interfaces.ts
+++ b/src/copy-to-clipboard/interfaces.ts
@@ -69,7 +69,6 @@ export interface CopyToClipboardProps extends BaseComponentProps {
   /**
    * Provides a reason why the copy to clipboard button is disabled (only when `disabled` is `true`).
    * If provided, the copy to clipboard button becomes focusable.
-   * Applicable for all variants except inline.
    */
   disabledReason?: string;
 


### PR DESCRIPTION
### Description

`disabledReason` only worked on the `normal`, `primary` and `icon` button variants. If we passed it to `link`, `inline-link` or `inline-icon`, the tooltip did not work, nor any reason/warnings exposed to screen readers. This code change makes it work on all the six variants.

The whole fix is one condition in `src/button/internal.tsx`, adding the three missing variants to the gate. Everything downstream already keyed off the `isDisabledWithReason` flag rather than the variant, so nothing else needed touching.

**One thing reviewers should know:** when `disabledReason` is set, the button drops the native `disabled` attribute and uses `aria-disabled` instead. That's not new, it's been the behavior for `normal`/`primary`/`icon` all along, because a natively disabled button can't be focused or hovered, so the tooltip could never be reached. This PR just extends it to three more variants. Plain `<Button disabled />` is untouched.

Worth calling out in the release notes, since `toBeDisabled()` will stop matching for these variants (test-utils `isDisabled()` handles both).

Two components have a side-effect as they render Button as their trigger and forward the prop -
1. `ButtonDropdown` with `variant="inline-icon"`
2. `CopyToClipboard` with `variant="inline"`
Both combinations were silently inert before. I added tests for them so it doesn't quietly regress later.

Also fixed the docs: `Button`'s JSDoc claimed only `link` was unsupported, which was already wrong, and `CopyToClipboard`'s correctly excluded `inline` and would have become wrong. Both are fixed, and the documenter snapshot is regenerated since that text feeds the published API docs.

I deleted the old `disabled with reason ignored for %s variant (not applicable)` test rather than inverting it, it asserted `tabIndex="-1"` for the exact case that now yields `"0"`. Both behaviors it covered still have tests elsewhere.

Open question: the [disabled and read-only states](https://cloudscape.design/patterns/general/disabled-and-read-only-states/) pattern still lists only primary, normal and icon as supporting this tooltip. So this needs a design call as well as a code review, and the pattern page should be updated if we go ahead.

Related links: Issue #60908

### How has this been tested?

Full build and the complete unit test.

On the unit side I widened the existing `describe.each` in `button.test.tsx` from 3 variants to 6, which runs its 14 assertions across both the `<button>` and `<a>` branches. Added `inline-icon` to ButtonDropdown's variant list, and turned CopyToClipboard's disabled-reason test into a `test.each` over all three of its variants.

To Test :
1. `npm start`
2. `#/light/button/disabled-reason`, `#/light/button-dropdown/disabled-reason` and `#/light/copy-to-clipboard/disabled-reason` (new page)


The following items are to be evaluated by the author(s) and the reviewer(s).

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_

</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
