### PR TITLE
fix: Name the emitted file in generated relative imports

### DIFF
--- a/build-tools/tasks/generate-i18n-messages.js
+++ b/build-tools/tasks/generate-i18n-messages.js
@@ -14,7 +14,7 @@ const targetI18nDir = path.resolve(targetPath, 'components/i18n');
 const targetMessagesDir = path.resolve(targetI18nDir, 'messages');
 
 const namespace = 'cloudscape-design-components';
-const messagesDeclarationFile = `import { I18nProviderProps } from "../provider";
+const messagesDeclarationFile = `import { I18nProviderProps } from "../provider.js";
 declare const messages: I18nProviderProps.Messages;
 export default messages;
 `;
@@ -52,8 +52,8 @@ module.exports = function generateI18nMessages() {
   // Generate a dynamic provider function for automatic bundler splitting and imports.
   const dynamicFile = [
     `import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
-import { isDevelopment } from '../internal/is-development';
-import { getMatchableLocales } from './utils/locales';
+import { isDevelopment } from '../internal/is-development.js';
+import { getMatchableLocales } from './utils/locales.js';
 
 export function importMessages(locale) {
   for (const matchableLocale of getMatchableLocales(locale)) {

--- a/build-tools/tasks/generate-index-file.js
+++ b/build-tools/tasks/generate-index-file.js
@@ -3,13 +3,14 @@
 const { pascalCase } = require('change-case');
 const { writeFile, listPublicItems } = require('../utils/files');
 
-const footer = `export * from './interfaces';\n`;
+// Specifiers name the emitted file, so the published package resolves under Node's ESM rules.
+const footer = `export * from './interfaces.js';\n`;
 
 module.exports = function generateIndexFile() {
   const content = listPublicItems('src')
     .map(componentDir => {
       const componentName = pascalCase(componentDir);
-      return `export { default as ${componentName}, ${componentName}Props } from './${componentDir}';\n`;
+      return `export { default as ${componentName}, ${componentName}Props } from './${componentDir}/index.js';\n`;
     })
     .join('');
   writeFile('src/index.ts', content + footer);


### PR DESCRIPTION
Part of adding support for Node's ESM resolver: #4948

Two build-time generators write relative import specifiers with no extension:

- `generate-index-file` writes `src/index.ts`, the root barrel. Its `export ... from './button'` is a directory import, and it is the first thing that fails in the repro on #4948.
- `generate-i18n-messages` writes `lib/components/i18n/dynamic.js` straight into the build output, importing `'../internal/is-development'` and `'./utils/locales'`.

This PR updates them to include the `.js` extension so that they can be resolved by Node.

## Verification

`tsc --noEmit -p tsconfig.json` reports 0 errors before and after: the repo's `moduleResolution: node` maps a `.js` specifier back to the `.ts` source, so `'./button/index.js'` resolves to `src/button/index.tsx` exactly as `'./button'` did.