### PR TITLE
feat: Support embedding StatusIndicator without container background in Steps

### DIFF
--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -36,6 +36,11 @@ export interface InternalStatusIndicatorProps
    * The CSS behavior of the status indicator container element.
    */
   __display?: 'inline' | 'inline-block';
+
+  /**
+   * Renders the status indicator without its container background, for embedding inside other components.
+   */
+  __embedded?: boolean;
 }
 
 const typeToIcon: (size: IconProps.Size) => Record<StatusIndicatorProps.Type, JSX.Element> = size => {
@@ -92,6 +97,7 @@ export default function StatusIndicator({
   __internalRootRef,
   __size = isThemeActive(Theme.OneTheme) ? 'x-small' : 'normal',
   __display = 'inline-block',
+  __embedded = false,
   ...rest
 }: InternalStatusIndicatorProps) {
   const baseProps = getBaseProps(rest);
@@ -104,6 +110,7 @@ export default function StatusIndicator({
       className={clsx(
         styles.root,
         styles[`status-${type}`],
+        __embedded && styles.embedded,
         {
           [styles[`color-override-${colorOverride}`]]: colorOverride,
         },

--- a/src/status-indicator/styles.scss
+++ b/src/status-indicator/styles.scss
@@ -64,13 +64,14 @@ $_background-overrides: (
       color: #{map.get($_color-overrides, $color)};
     }
   }
+
   @each $status in map.keys($_status-backgrounds) {
-    &.status-#{$status} > .container {
+    &.status-#{$status}:not(.embedded) > .container {
       background: #{map.get($_status-backgrounds, $status)};
     }
   }
   @each $color in map.keys($_background-overrides) {
-    &.color-override-#{$color} > .container {
+    &.color-override-#{$color}:not(.embedded) > .container {
       background: #{map.get($_background-overrides, $color)};
     }
   }

--- a/src/steps/internal.tsx
+++ b/src/steps/internal.tsx
@@ -111,7 +111,7 @@ const InternalStep = ({
         {orientation === 'vertical' ? (
           <>
             <div className={styles.header}>
-              <InternalStatusIndicator type={status} iconAriaLabel={statusIconAriaLabel}>
+              <InternalStatusIndicator __embedded={true} type={status} iconAriaLabel={statusIconAriaLabel}>
                 {header}
               </InternalStatusIndicator>
             </div>


### PR DESCRIPTION
### Description

When a StatusIndicator is rendered inside the Steps component (vertical orientation), it shows its container background — the colored "pill" behind the icon and text. In the Steps context this background is visually
undesirable; the status indicator should render inline, showing only the icon and text.

## Scope
- Affects Steps (vertical orientation) only.
- Standalone StatusIndicator and all other consumers must keep their
  existing background.

### How has this been tested?

Unit tests 
Screenshot tests 

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
