### PR TITLE
chore: tag one theme prop

### DIFF
--- a/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/snapshot-tests/__snapshots__/documenter.test.ts.snap
@@ -5183,7 +5183,9 @@ The object accepts the following fields:
   \`full\` for fully rounded corners. When not set, the wrapper has no border radius. Set it to
   \`full\` together with \`aspectRatio: 'equal'\` to render a circle.
 
-Composes with existing Box props such as \`padding\` and \`margin\`.",
+Composes with existing Box props such as \`padding\` and \`margin\`.
+
+This is a One Theme only feature and must not be used in VR.",
       "inlineType": {
         "name": "BoxProps.VisualAccent",
         "properties": [
@@ -5251,6 +5253,9 @@ Composes with existing Box props such as \`padding\` and \`margin\`.",
       },
       "name": "visualAccent",
       "optional": true,
+      "systemTags": [
+        "one-theme",
+      ],
       "type": "BoxProps.VisualAccent",
     },
   ],

--- a/src/box/interfaces.ts
+++ b/src/box/interfaces.ts
@@ -44,6 +44,9 @@ export interface BoxProps extends BaseComponentProps {
    *   `full` together with `aspectRatio: 'equal'` to render a circle.
    *
    * Composes with existing Box props such as `padding` and `margin`.
+   *
+   * This is a One Theme only feature and must not be used in VR.
+   * @awsuiSystem one-theme
    */
   visualAccent?: BoxProps.VisualAccent;
   /**


### PR DESCRIPTION
### Description

Tags One Theme only prop so it can properly be omitted in VR docs.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
